### PR TITLE
Switched all CESM gn entries to X Right, Y Right

### DIFF
--- a/cmip6_preprocessing/specs/staggered_grid_config.yaml
+++ b/cmip6_preprocessing/specs/staggered_grid_config.yaml
@@ -31,8 +31,8 @@ CAS-ESM2-0:
 CESM1-1-CAM5-CMIP5:
   gn:
     axis_shift:
-      X: left
-      Y: left
+      X: right
+      Y: right
   gr:
     axis_shift:
       X: left
@@ -40,7 +40,7 @@ CESM1-1-CAM5-CMIP5:
 CESM2:
   gn:
     axis_shift:
-      X: left
+      X: right
       Y: right
   gr:
     axis_shift:
@@ -49,8 +49,8 @@ CESM2:
 CESM2-FV2:
   gn:
     axis_shift:
-      X: left
-      Y: left
+      X: right
+      Y: right
   gr:
     axis_shift:
       X: left
@@ -58,7 +58,7 @@ CESM2-FV2:
 CESM2-WACCM:
   gn:
     axis_shift:
-      X: left
+      X: right
       Y: right
   gr:
     axis_shift:
@@ -67,7 +67,7 @@ CESM2-WACCM:
 CESM2-WACCM-FV2:
   gn:
     axis_shift:
-      X: left
+      X: right
       Y: right
   gr:
     axis_shift:


### PR DESCRIPTION
I've updated all CESM native grid descriptions in staggered_grid_config.yaml to X:right and Y:right, which matches the original POP grid. We discussed this issue here: https://github.com/jbusecke/cmip6_preprocessing/issues/240

Let me know if anything looks amiss and I can try again.