### PR TITLE
Increase ci time

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
     name: Build (${{ matrix.python-version }} | ${{ matrix.os }})
     if: github.repository == 'jbusecke/xmip'
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 45
     defaults:
       run:
         shell: bash -l {0}


### PR DESCRIPTION
Trying to deal with failures in the CI for python 3.7 

It seems like there is something in the conda env resolution that takes very long for py3.7, whereas the other versions run fast (~7 min).