### PR TITLE
More flexible metric matching + better error for missing match_attrs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
 #       args: [--config=pyproject.toml]
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.1.0
+  rev: v4.4.0
   hooks:
     - id: trailing-whitespace
       exclude: tests/data
@@ -21,27 +21,25 @@ repos:
     - id: file-contents-sorter
       files: requirements-dev.txt
 
-- repo: https://gitlab.com/pycqa/flake8
-  rev: 3.7.9
+- repo: https://github.com/PyCQA/flake8
+  rev: 6.0.0
   hooks:
     - id: flake8
-      exclude: docs/source/conf.py
-      args: [--max-line-length=105, --ignore=E203,E501,W503, --select=select=C,E,F,W,B,B950]
 
 - repo: https://github.com/pre-commit/mirrors-isort
-  rev: v4.3.21
+  rev: v5.10.1
   hooks:
   - id: isort
     additional_dependencies: [toml]
-    args: [--project=gcm_filters, --multi-line=3, --lines-after-imports=2, --lines-between-types=1, --trailing-comma, --force-grid-wrap=0, --use-parentheses, --line-width=88]
+    args: [--project=xmip, --multi-line=3, --lines-after-imports=2, --lines-between-types=1, --trailing-comma, --force-grid-wrap=0, --use-parentheses, --line-width=88]
 
 - repo: https://github.com/asottile/seed-isort-config
-  rev: v2.1.1
+  rev: v2.2.0
   hooks:
     - id: seed-isort-config
 
 - repo: https://github.com/psf/black
-  rev: 22.3.0
+  rev: 22.12.0
   hooks:
   - id: black
     language_version: python3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ quiet = false
 color = true
 
 [tool.isort]
-known_third_party = ["cf_xarray", "cftime", "dask", "fsspec", "numpy", "pandas", "pint", "pint_xarray", "pkg_resources", "pytest", "setuptools", "xarray", "xarrayutils", "xesmf", "xgcm", "yaml"]
+known_third_party = ["cf_xarray", "cftime", "dask", "fsspec", "numpy", "pint", "pint_xarray", "pkg_resources", "pytest", "setuptools", "xarray", "xarrayutils", "xesmf", "xgcm", "yaml"]
+
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,10 @@ ignore =
 max-line-length = 105
 select = C,E,F,W,B,B950
 ignore = E203, E501, W503
-exclude = xmip/_version.py
+exclude =
+    xmip/_version.py
+    docs/*
+    __init__.py
 
 
 [metadata]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,0 @@
-import pytest
-
-
-def pytest_addoption(parser):
-    parser.addoption("--cat", action="store", default="main")
-    parser.addoption("--vi", action="store", default="thetao")
-    parser.addoption("--gl", action="store", default="gn")
-    parser.addoption("--ei", action="store", default="historical")
-    parser.addoption("--models", action="store", default="all")

--- a/tests/test_drift_removal.py
+++ b/tests/test_drift_removal.py
@@ -14,7 +14,7 @@ from xmip.drift_removal import (
     replace_time,
     unify_time,
 )
-from xmip.postprocessing import exact_attrs
+from xmip.postprocessing import EXACT_ATTRS
 from xmip.utils import cmip6_dataset_id
 
 
@@ -545,7 +545,7 @@ def test_match_and_remove_trend_matching_experiment(ref_date):
     nt = 24
     time_historical = xr.cftime_range("1850-01-01", periods=nt, freq="1MS")
     time_ssp = xr.cftime_range("2014-01-01", periods=nt, freq="1MS")
-    raw_attrs = {k: "dummy" for k in exact_attrs + ["variable_id"]}
+    raw_attrs = {k: "dummy" for k in EXACT_ATTRS + ["variable_id"]}
 
     ds_a_hist_vara = xr.DataArray(
         np.random.rand(nx, ny, nt),
@@ -634,9 +634,9 @@ def test_match_and_remove_trend_nomatch():
     # create two datasets that do not match (according to the hardcoded conventions in `match_and_detrend`)
     attrs = {}
     ds = xr.DataArray().to_dataset(name="test")
-    ds.attrs = {k: "a" for k in exact_attrs + ["variable_id"]}
+    ds.attrs = {k: "a" for k in EXACT_ATTRS + ["variable_id"]}
     ds_nomatch = xr.DataArray().to_dataset(name="test")
-    ds_nomatch.attrs = {k: "b" for k in exact_attrs + ["variable_id"]}
+    ds_nomatch.attrs = {k: "b" for k in EXACT_ATTRS + ["variable_id"]}
 
     detrended = match_and_remove_trend({"aa": ds}, {"bb": ds_nomatch}, nomatch="ignore")
     assert detrended == {}
@@ -657,7 +657,7 @@ def test_match_and_remove_trend_nonunique():
     # create two datasets that do not match (according to the hardcoded conventions in `match_and_detrend`)
     attrs = {}
     ds = xr.DataArray().to_dataset(name="test")
-    ds.attrs = {k: "a" for k in exact_attrs + ["variable_id"]}
+    ds.attrs = {k: "a" for k in EXACT_ATTRS + ["variable_id"]}
     ds_match_a = xr.DataArray().to_dataset(name="test")
     ds_match_b = xr.DataArray().to_dataset(name="test")
     ds_match_a.attrs = ds.attrs

--- a/tests/test_drift_removal.py
+++ b/tests/test_drift_removal.py
@@ -84,8 +84,10 @@ def test_replace_time_error_other_freq():
     ds = xr.DataArray(
         np.random.rand(nt), dims=timename, coords={timename: time}
     ).to_dataset(name="test")
-    with pytest.raises(ValueError) as einfo:
-        ds_new = replace_time(ds, freq="1DS")
+    with pytest.raises(
+        ValueError, match="replace_time` currently only works with monthly data."
+    ):
+        replace_time(ds, freq="1DS")
 
 
 @pytest.mark.parametrize(
@@ -299,7 +301,7 @@ def test_remove_trend(chunk):
 
     # test the additional output when the slope input does not have sufficient information
 
-    with pytest.warns(UserWarning) as winfo:
+    with pytest.warns(UserWarning):
         detrended = remove_trend(
             sloped_data, slope.drop_vars("trend_time_range"), "test", ref_date
         )
@@ -342,7 +344,6 @@ def test_remove_trend_exceptions(chunk):
     slope = xr.DataArray(np.random.rand(3, 4), dims=["x", "y"])
 
     ref_date = str(time[0])
-    dummy_time = xr.DataArray(np.arange(len(time)), dims=["time"])
     with pytest.raises(ValueError) as einfo:
         remove_trend(data, slope.to_dataset(name="test"), "test", ref_date)
     assert str(einfo.value) == "`ds` input needs to be a dataset"
@@ -479,12 +480,9 @@ def test_calculate_drift_exceptions():
         "source_id": "a",
         "variant_label": "a",
     }
-    with pytest.raises(RuntimeError) as einfo:
-        reg = calculate_drift(ds_control, ds, "test")
-    assert (
-        str(einfo.value)
-        == "Selecting from `reference` according to the branch time resulted in empty dataset. Check the metadata."
-    )
+    msg = "Selecting from `reference` according to the branch time resulted in empty dataset. Check the metadata."
+    with pytest.raises(RuntimeError, match=msg):
+        calculate_drift(ds_control, ds, "test")
 
 
 def test_calculate_drift_exceptions_partial():
@@ -520,16 +518,13 @@ def test_calculate_drift_exceptions_partial():
         "source_id": "a",
         "variant_label": "a",
     }
-    with pytest.raises(RuntimeError) as einfo:
-        reg = calculate_drift(ds_control, ds, "test")
-    assert (
-        "Set `calculate_short_trend=True` to compute from a shorter timeseries"
-        in str(einfo.value)
-    )
+    msg = "Set `calculate_short_trend=True` to compute from a shorter timeseries"
+    with pytest.raises(RuntimeError, match=msg):
+        calculate_drift(ds_control, ds, "test")
     # TODO: Assert the correct time limits in the attrs
 
     with pytest.warns(UserWarning) as winfo:
-        reg = calculate_drift(ds_control, ds, "test", compute_short_trends=True)
+        calculate_drift(ds_control, ds, "test", compute_short_trends=True)
     assert any(
         [
             "years to calculate trend. Using 1 years only" in w.message.args[0]
@@ -632,7 +627,6 @@ def test_match_and_remove_trend_matching_experiment(ref_date):
 
 def test_match_and_remove_trend_nomatch():
     # create two datasets that do not match (according to the hardcoded conventions in `match_and_detrend`)
-    attrs = {}
     ds = xr.DataArray().to_dataset(name="test")
     ds.attrs = {k: "a" for k in EXACT_ATTRS + ["variable_id"]}
     ds_nomatch = xr.DataArray().to_dataset(name="test")
@@ -655,7 +649,6 @@ def test_match_and_remove_trend_nomatch():
 
 def test_match_and_remove_trend_nonunique():
     # create two datasets that do not match (according to the hardcoded conventions in `match_and_detrend`)
-    attrs = {}
     ds = xr.DataArray().to_dataset(name="test")
     ds.attrs = {k: "a" for k in EXACT_ATTRS + ["variable_id"]}
     ds_match_a = xr.DataArray().to_dataset(name="test")
@@ -665,6 +658,4 @@ def test_match_and_remove_trend_nonunique():
 
     match_msg = "Found more than one matching dataset for *"
     with pytest.raises(ValueError, match=match_msg):
-        detrended = match_and_remove_trend(
-            {"aa": ds}, {"bb": ds_match_a, "cc": ds_match_b}
-        )
+        match_and_remove_trend({"aa": ds}, {"bb": ds_match_a, "cc": ds_match_b})

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -322,7 +322,7 @@ def test_recreate_metrics(xshift, yshift, z_axis):
         assert set(["X", "Y", "Z"]).issubset(set(metrics_dict.keys()))
     else:
         assert set(["X", "Y"]).issubset(set(metrics_dict.keys()))
-        assert not "Z" in list(metrics_dict.keys())
+        assert "Z" not in list(metrics_dict.keys())
 
 
 # TODO: inner and outer (needs to be implemented in xgcm autogenerate first)

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -64,7 +64,7 @@ def test_parse_metric_exceptions(metricname):
 
     # provide dataset instead of dataarray
     with pytest.raises(ValueError):
-        ds_parsed = _parse_metric(ds, ds_metric)
+        _parse_metric(ds, ds_metric)
 
 
 def test_parse_metric_exceptions_input_name():
@@ -80,7 +80,7 @@ def test_parse_metric_exceptions_input_name():
         da_metric_nameless = ds_metric["data"]
         da_metric_nameless.name = None
 
-        ds_parsed = _parse_metric(ds, da_metric_nameless)
+        _parse_metric(ds, da_metric_nameless)
     assert (
         warninfo[0].message.args[0]
         == "a.none.none.none.none.none.none.none.none:`metric` has no name. This might lead to problems down the line."
@@ -98,9 +98,7 @@ def test_parse_metric_exception_dim_length():
 
     # provide dataarray with non-matching dimensions
     with pytest.raises(ValueError) as execinfo:
-        ds_parsed = _parse_metric(
-            ds, ds_metric.isel(x=slice(0, -1), y=slice(1, None))[metricname]
-        )
+        _parse_metric(ds, ds_metric.isel(x=slice(0, -1), y=slice(1, None))[metricname])
     msg = "a.none.none.none.none.none.g.none.none:`metric` dimensions ['x:2', 'y:1'] do not match `ds` ['x:3', 'y:2']."
     assert execinfo.value.args[0] == msg
 
@@ -186,7 +184,7 @@ def test_match_metrics(metricname):
     ds_metric = random_ds().isel(time=0).rename({"data": metricname})
     ds_metric.attrs = ds_a.attrs
 
-    #FIXME: This needs to be factored out
+    # FIXME: This needs to be factored out
     def _assert_parsed_ds_dict(ddict_parsed, expected, match_keys, strict=True):
         expected = expected.copy()
         for i in match_keys:
@@ -250,11 +248,12 @@ def test_match_metrics(metricname):
     ds_dict_parsed = match_metrics(ds_dict, metric_dict, match_variables=[metricname])
     _assert_parsed_ds_dict(ds_dict_parsed, ds_metric[metricname], ["a"])
 
+
 def test_match_metrics_missing_attr():
-    """This test ensures that as long as the provided `match_metrics` are 
-    given they will be matched. This is relevant if e.g. the variant label 
+    """This test ensures that as long as the provided `match_metrics` are
+    given they will be matched. This is relevant if e.g. the variant label
     has been removed due to merging"""
-    metricname = 'area'
+    metricname = "area"
     ds_a = random_ds()
     ds_a.attrs = {
         "source_id": "a",
@@ -262,34 +261,37 @@ def test_match_metrics_missing_attr():
     }
     ds_metric = random_ds().isel(time=0).rename({"data": metricname})
     ds_metric.attrs = ds_a.attrs
-    
+
     ds_dict = {"a": ds_a}
     metric_dict = {"something": ds_metric}
     expected = ds_metric[metricname]
 
     ds_dict_parsed = match_metrics(ds_dict, metric_dict, [metricname])
 
-    assert 'a' in ds_dict_parsed.keys()
-    #TODO this should be factored out into _assert_parsed_ds_dict from the test above
-    xr.testing.assert_allclose(expected, ds_dict_parsed['a'][metricname].reset_coords(drop=True))
+    assert "a" in ds_dict_parsed.keys()
+    # TODO this should be factored out into _assert_parsed_ds_dict from the test above
+    xr.testing.assert_allclose(
+        expected, ds_dict_parsed["a"][metricname].reset_coords(drop=True)
+    )
+
 
 def test_match_metrics_missing_match_attrs():
     """If one of the `match_attrs` is not in the dataset this should error out"""
-    metricname = 'area'
+    metricname = "area"
     ds_a = random_ds()
     ds_a.attrs = {
         "source_id": "a",
     }
     ds_metric = random_ds().isel(time=0).rename({"data": metricname})
     ds_metric.attrs = ds_a.attrs
-    
+
     ds_dict = {"a": ds_a}
     metric_dict = {"something": ds_metric}
-    expected = ds_metric[metricname]
-    with pytest.raises(ValueError, match='Cannot match datasets because at least one of the datasets does not contain all attributes'):
-        ds_dict_parsed = match_metrics(ds_dict, metric_dict, [metricname])
-
-
+    with pytest.raises(
+        ValueError,
+        match="Cannot match datasets because at least one of the datasets does not contain all attributes",
+    ):
+        match_metrics(ds_dict, metric_dict, [metricname])
 
 
 def test_match_metrics_closer(metricname):
@@ -657,7 +659,6 @@ def test_concat_experiments(concat_kwargs):
 
 
 def test_pick_first_member():
-    concat_kwargs = {}
 
     attrs_a = {
         "source_id": "a",

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -186,6 +186,7 @@ def test_match_metrics(metricname):
     ds_metric = random_ds().isel(time=0).rename({"data": metricname})
     ds_metric.attrs = ds_a.attrs
 
+    #FIXME: This needs to be factored out
     def _assert_parsed_ds_dict(ddict_parsed, expected, match_keys, strict=True):
         expected = expected.copy()
         for i in match_keys:
@@ -248,6 +249,47 @@ def test_match_metrics(metricname):
 
     ds_dict_parsed = match_metrics(ds_dict, metric_dict, match_variables=[metricname])
     _assert_parsed_ds_dict(ds_dict_parsed, ds_metric[metricname], ["a"])
+
+def test_match_metrics_missing_attr():
+    """This test ensures that as long as the provided `match_metrics` are 
+    given they will be matched. This is relevant if e.g. the variant label 
+    has been removed due to merging"""
+    metricname = 'area'
+    ds_a = random_ds()
+    ds_a.attrs = {
+        "source_id": "a",
+        "grid_label": "a",
+    }
+    ds_metric = random_ds().isel(time=0).rename({"data": metricname})
+    ds_metric.attrs = ds_a.attrs
+    
+    ds_dict = {"a": ds_a}
+    metric_dict = {"something": ds_metric}
+    expected = ds_metric[metricname]
+
+    ds_dict_parsed = match_metrics(ds_dict, metric_dict, [metricname])
+
+    assert 'a' in ds_dict_parsed.keys()
+    #TODO this should be factored out into _assert_parsed_ds_dict from the test above
+    xr.testing.assert_allclose(expected, ds_dict_parsed['a'][metricname].reset_coords(drop=True))
+
+def test_match_metrics_missing_match_attrs():
+    """If one of the `match_attrs` is not in the dataset this should error out"""
+    metricname = 'area'
+    ds_a = random_ds()
+    ds_a.attrs = {
+        "source_id": "a",
+    }
+    ds_metric = random_ds().isel(time=0).rename({"data": metricname})
+    ds_metric.attrs = ds_a.attrs
+    
+    ds_dict = {"a": ds_a}
+    metric_dict = {"something": ds_metric}
+    expected = ds_metric[metricname]
+    with pytest.raises(ValueError, match='Cannot match datasets because at least one of the datasets does not contain all attributes'):
+        ds_dict_parsed = match_metrics(ds_dict, metric_dict, [metricname])
+
+
 
 
 def test_match_metrics_closer(metricname):

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from xmip.postprocessing import exact_attrs
+from xmip.postprocessing import EXACT_ATTRS
 from xmip.preprocessing import (
     broadcast_lonlat,
     cmip6_renaming_dict,
@@ -500,7 +500,7 @@ def test_preserve_attrs():
     # TODO:  there are a bunch of errors if the metadata is not full.
     # I should probably ignore them and still put the datset out?
     # Well for now create one
-    for att in exact_attrs:
+    for att in EXACT_ATTRS:
         ds.attrs[att] = "a"
 
     ds_pp = combined_preprocessing(ds)

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -438,7 +438,7 @@ def test_fix_metadata():
         "branch_time_in_parent": "nonsense",
     }
     ds_fixed = fix_metadata(ds)
-    assert ds.attrs["branch_time_in_parent"] == 91250
+    assert ds_fixed.attrs["branch_time_in_parent"] == 91250
 
     # Test that another dataset is untouched
     ds = xr.Dataset()
@@ -448,12 +448,10 @@ def test_fix_metadata():
         "branch_time_in_parent": "nonsense",
     }
     ds_fixed = fix_metadata(ds)
-    assert ds.attrs["branch_time_in_parent"] == "nonsense"
+    assert ds_fixed.attrs["branch_time_in_parent"] == "nonsense"
 
 
-### Combination test - involving###
-
-
+# Combination test - involving #
 @pytest.mark.parametrize("add_coords", [True, False])
 @pytest.mark.parametrize("shift", [0, 10])
 def test_combined_preprocessing_dropped_coords(add_coords, shift):

--- a/tests/test_regionmask.py
+++ b/tests/test_regionmask.py
@@ -2,7 +2,6 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from xmip.preprocessing import combined_preprocessing
 from xmip.regionmask import _default_merge_dict, merged_mask
 
 

--- a/xmip/__init__.py
+++ b/xmip/__init__.py
@@ -1,13 +1,13 @@
 try:
-    from importlib.metadata import (
-        version,
+    from importlib.metadata import (  # only works for python 3.8 and upwards
         PackageNotFoundError,
-    )  # only works for python 3.8 and upwards
+        version,
+    )
 except:
-    from importlib_metadata import (
-        version,
+    from importlib_metadata import (  # works for python <3.8
         PackageNotFoundError,
-    )  # works for python <3.8
+        version,
+    )
 
 try:
     __version__ = version("xmip")

--- a/xmip/drift_removal.py
+++ b/xmip/drift_removal.py
@@ -7,7 +7,7 @@ import xarrayutils as xru
 
 from xarrayutils.utils import linear_trend
 
-from xmip.postprocessing import _match_datasets, EXACT_ATTRS
+from xmip.postprocessing import EXACT_ATTRS, _match_datasets
 from xmip.utils import cmip6_dataset_id
 
 
@@ -43,7 +43,7 @@ def replace_time(
     """This function replaces the time encoding of a dataset acoording to `ref_date`.
     The ref date can be any index of ds.time (default is 0; meaning the first timestep of ds will be replaced with `ref_date`).
     """
-    #! I might be able to achieve some of this with time.shift
+    # ! I might be able to achieve some of this with time.shift
     # !
 
     if calendar is None:
@@ -101,7 +101,6 @@ def unify_time(parent, child, adjust_to="child"):
     Similar to `switch_to_child_time`, but sets the time parameters (e.g. calendar) explicitly to the child conventions
     """
     branch_time_in_parent = child.attrs.get("branch_time_in_parent")
-    parent_time_units = child.attrs.get("parent_time_units")
 
     # if branch time is not in attrs do nothing
     if branch_time_in_parent is None:
@@ -180,7 +179,7 @@ def calculate_drift(
         "source_id",
         "variant_label",
     ]:
-        if not attr in ds.attrs:
+        if attr not in ds.attrs:
             raise ValueError(f"Could not find {attr} in attributes of `ds`.")
 
     # Check if the parent member id matches
@@ -208,7 +207,7 @@ def calculate_drift(
 
     if len(reference_cut.time) == 0:
         raise RuntimeError(
-            f"Selecting from `reference` according to the branch time resulted in empty dataset. Check the metadata."
+            "Selecting from `reference` according to the branch time resulted in empty dataset. Check the metadata."
         )
         return None
     else:
@@ -234,9 +233,9 @@ def calculate_drift(
         # strings
         time_range = time_range.astype(str)
 
-        # # The polyfit implementation actually respects the units.
-        # # For now my implementation requires the slope to be in units .../month
-        # # I might be able to change this later and accomodate other time frequencies?
+        # The polyfit implementation actually respects the units.
+        # For now my implementation requires the slope to be in units .../month
+        # I might be able to change this later and accomodate other time frequencies?
         # get rid of all the additional coords, which resets the time to an integer index
 
         reference_cut = reference_cut[variable]
@@ -253,7 +252,7 @@ def calculate_drift(
             "time",
         )
 
-        #! quite possibly the shittiest fix ever.
+        # ! quite possibly the shittiest fix ever.
         # I changed the API over at xarrayutils and now I have to pay the price over here.
         # TODO: Might want to eliminate this ones the new xarrayutils version has matured.
         if xru.__version__ > "v0.1.3":
@@ -288,7 +287,7 @@ def detrend_basic(da, da_slope, start_idx=0, dim="time", keep_attrs=True):
     """Basic detrending just based on time index, not date"""
     # now create a trend timeseries at each point
     # and the time indicies by the ref index. This way the trend is correctly calculated from the reference year.
-    ## this adapts the chunk structure from the input if its a dask array
+    # this adapts the chunk structure from the input if its a dask array
     attrs = {k: v for k, v in da.attrs.items()}
     idx_start = -start_idx
     idx_stop = len(da.time) - start_idx
@@ -404,7 +403,6 @@ def match_and_remove_trend(
         trend_ds = _match_datasets(
             ds, trend_ddict, match_attrs, pop=False, unique=True, nomatch=nomatch
         )
-        # # print(trend_ds)
         if len(trend_ds) == 2:
             trend_ds = trend_ds[
                 1

--- a/xmip/drift_removal.py
+++ b/xmip/drift_removal.py
@@ -7,7 +7,7 @@ import xarrayutils as xru
 
 from xarrayutils.utils import linear_trend
 
-from xmip.postprocessing import _match_datasets, exact_attrs
+from xmip.postprocessing import _match_datasets, EXACT_ATTRS
 from xmip.utils import cmip6_dataset_id
 
 
@@ -396,7 +396,7 @@ def match_and_remove_trend(
 
     """
     ddict_detrended = {}
-    match_attrs = [ma for ma in exact_attrs if ma not in ["experiment_id"]] + [
+    match_attrs = [ma for ma in EXACT_ATTRS if ma not in ["experiment_id"]] + [
         "variable_id"
     ]
 

--- a/xmip/postprocessing.py
+++ b/xmip/postprocessing.py
@@ -1,7 +1,8 @@
 import functools
 import inspect
 import warnings
-from typing import Mapping, List
+
+from typing import List, Mapping
 
 import numpy as np
 import xarray as xr
@@ -33,8 +34,9 @@ def _match_attrs(ds_a, ds_b, match_attrs):
         n_match = sum([ds_a.attrs[i] == ds_b.attrs[i] for i in match_attrs])
         return n_match
     except KeyError:
-        raise ValueError(f'Cannot match datasets because at least one of the datasets does not contain all attributes [{match_attrs}].')
-
+        raise ValueError(
+            f"Cannot match datasets because at least one of the datasets does not contain all attributes [{match_attrs}]."
+        )
 
 
 def _match_datasets(ds, ds_dict, match_attrs, pop=True, nomatch="ignore", unique=False):
@@ -73,7 +75,10 @@ def _match_datasets(ds, ds_dict, match_attrs, pop=True, nomatch="ignore", unique
             )
     return datasets
 
-def _prune_match_attrs_to_available(match_attrs: List[str], ds_dict: Mapping[str,xr.Dataset]) -> List[str]:
+
+def _prune_match_attrs_to_available(
+    match_attrs: List[str], ds_dict: Mapping[str, xr.Dataset]
+) -> List[str]:
     """prune a set of attrs to only the ones available in every dataset"""
     missing_match_attrs = []
     for ma in match_attrs:
@@ -90,7 +95,6 @@ def _prune_match_attrs_to_available(match_attrs: List[str], ds_dict: Mapping[str
         return pruned_match_attrs
     else:
         return match_attrs
-
 
 
 def combine_datasets(
@@ -155,7 +159,7 @@ def combine_datasets(
     return ds_dict_combined
 
 
-### Convenience Wrappers for `combine_datasets`. Less flexible but easier to use and understand.
+# Convenience Wrappers for `combine_datasets`. Less flexible but easier to use and understand.
 def merge_variables(
     ds_dict,
     merge_kwargs={},
@@ -178,7 +182,6 @@ def merge_variables(
 
     """
     # An exact match is only possible if all attrs in `EXACT_ATTRS` are in every dataset
-
 
     match_attrs = [ma for ma in EXACT_ATTRS if ma not in ["variable_id"]]
 
@@ -306,7 +309,7 @@ def pick_first_member(ddict):
     )
 
 
-### Matching wrapper specific to combining grid labels via interpolation with xesmf
+# Matching wrapper specific to combining grid labels via interpolation with xesmf
 def requires_xesmf(func):
     @functools.wraps(func)
     def wrapper_requires_xesmf(*args, **kwargs):
@@ -519,7 +522,7 @@ def interpolate_grid_label(
     )
 
 
-### Matching wrapper specific to metric datasets
+# Matching wrapper specific to metric datasets
 
 
 def _parse_metric(ds, metric, dim_length_conflict="error"):
@@ -606,7 +609,7 @@ def match_metrics(
     match_variables : list
         Data variables of datasets in `metric_dict` to parse.
     match_attrs : list, optional
-        Minimum dataset attributes that need to match, by default ["source_id", "grid_label"]. 
+        Minimum dataset attributes that need to match, by default ["source_id", "grid_label"].
         Pass "exact" to only allow exact matches using all required attributes.
     print_statistics : bool, optional
         Option to print statistics about matching, by default False
@@ -621,13 +624,12 @@ def match_metrics(
     """
     # metrics should never match the variable
     exact_attrs_wo_var = [ma for ma in EXACT_ATTRS if ma != "variable_id"]
-    
-    #TODO: this naming is a big weird. Basically this here is necessary to still get a 'closest match' on whichever of the full
+
+    # TODO: this naming is a big weird. Basically this here is necessary to still get a 'closest match' on whichever of the full
     # set of 'exact' attrs are given on each of the datasets
     pruned_attrs = _prune_match_attrs_to_available(exact_attrs_wo_var, ds_dict)
     # and this also needs to be true for the metrics of course.
     pruned_attrs = _prune_match_attrs_to_available(pruned_attrs, metric_dict)
-
 
     match_variables = _maybe_make_list(match_variables)
 

--- a/xmip/postprocessing.py
+++ b/xmip/postprocessing.py
@@ -1,6 +1,7 @@
 import functools
 import inspect
 import warnings
+from typing import Mapping, List
 
 import numpy as np
 import xarray as xr
@@ -72,7 +73,7 @@ def _match_datasets(ds, ds_dict, match_attrs, pop=True, nomatch="ignore", unique
             )
     return datasets
 
-def _prune_match_attrs_to_available(match_attrs: list[str], ds_dict: dict[str,xr.Dataset]):
+def _prune_match_attrs_to_available(match_attrs: List[str], ds_dict: Mapping[str,xr.Dataset]) -> List[str]:
     """prune a set of attrs to only the ones available in every dataset"""
     missing_match_attrs = []
     for ma in match_attrs:

--- a/xmip/preprocessing.py
+++ b/xmip/preprocessing.py
@@ -1,11 +1,10 @@
 # Preprocessing for CMIP6 models
 import warnings
 
-import cf_xarray.units
+import cf_xarray.units  # noqa: F401
 import numpy as np
-import pandas as pd
-import pint
-import pint_xarray
+import pint  # noqa: F401
+import pint_xarray  # noqa: F401
 import xarray as xr
 
 from xmip.utils import _maybe_make_list, cmip6_dataset_id
@@ -103,7 +102,8 @@ def rename_cmip6(ds, rename_dict=None):
     for va in ds.data_vars:
         try:
             ds = ds.rename({va: inverted_rename_dict[va]})
-        except:
+        except Exception as e:
+            warnings.warn(f"Renaming failed with {e}")
             pass
 
     # restore attributes

--- a/xmip/regionmask.py
+++ b/xmip/regionmask.py
@@ -1,5 +1,3 @@
-import warnings
-
 import numpy as np
 import xarray as xr
 


### PR DESCRIPTION
I recently encountered an error when trying to match metrics for already aggregated (members) datasets from intake-esm. This PR introduces a more flexible matching: 
- We still prefer the closest match, but this only takes into account attributes that are present on all datasets (+metric datasets). As long as the given `match_attrs` are in each dataset a match is performed (this previously errored).
- If any of the datasets is missing one of `match_attrs`, the error message is now more clear.