### PR TITLE
More flexible member concatenation

### DIFF
--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -249,52 +249,7 @@ def test_match_metrics(metricname):
     _assert_parsed_ds_dict(ds_dict_parsed, ds_metric[metricname], ["a"])
 
 
-def test_match_metrics_missing_attr():
-    """This test ensures that as long as the provided `match_metrics` are
-    given they will be matched. This is relevant if e.g. the variant label
-    has been removed due to merging"""
-    metricname = "area"
-    ds_a = random_ds()
-    ds_a.attrs = {
-        "source_id": "a",
-        "grid_label": "a",
-    }
-    ds_metric = random_ds().isel(time=0).rename({"data": metricname})
-    ds_metric.attrs = ds_a.attrs
-
-    ds_dict = {"a": ds_a}
-    metric_dict = {"something": ds_metric}
-    expected = ds_metric[metricname]
-
-    ds_dict_parsed = match_metrics(ds_dict, metric_dict, [metricname])
-
-    assert "a" in ds_dict_parsed.keys()
-    # TODO this should be factored out into _assert_parsed_ds_dict from the test above
-    xr.testing.assert_allclose(
-        expected, ds_dict_parsed["a"][metricname].reset_coords(drop=True)
-    )
-
-
-def test_match_metrics_missing_match_attrs():
-    """If one of the `match_attrs` is not in the dataset this should error out"""
-    metricname = "area"
-    ds_a = random_ds()
-    ds_a.attrs = {
-        "source_id": "a",
-    }
-    ds_metric = random_ds().isel(time=0).rename({"data": metricname})
-    ds_metric.attrs = ds_a.attrs
-
-    ds_dict = {"a": ds_a}
-    metric_dict = {"something": ds_metric}
-    with pytest.raises(
-        ValueError,
-        match="Cannot match datasets because at least one of the datasets does not contain all attributes",
-    ):
-        match_metrics(ds_dict, metric_dict, [metricname])
-
-
-def test_match_metrics_missing_attr():
+def test_match_metrics_missing_non_match_attr():
     """This test ensures that as long as the provided `match_metrics` are
     given they will be matched. This is relevant if e.g. the variant label
     has been removed due to merging"""

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -248,11 +248,12 @@ def test_match_metrics(metricname):
     ds_dict_parsed = match_metrics(ds_dict, metric_dict, match_variables=[metricname])
     _assert_parsed_ds_dict(ds_dict_parsed, ds_metric[metricname], ["a"])
 
+
 def test_match_metrics_missing_attr():
-    """This test ensures that as long as the provided `match_metrics` are 
-    given they will be matched. This is relevant if e.g. the variant label 
+    """This test ensures that as long as the provided `match_metrics` are
+    given they will be matched. This is relevant if e.g. the variant label
     has been removed due to merging"""
-    metricname = 'area'
+    metricname = "area"
     ds_a = random_ds()
     ds_a.attrs = {
         "source_id": "a",
@@ -260,34 +261,37 @@ def test_match_metrics_missing_attr():
     }
     ds_metric = random_ds().isel(time=0).rename({"data": metricname})
     ds_metric.attrs = ds_a.attrs
-    
+
     ds_dict = {"a": ds_a}
     metric_dict = {"something": ds_metric}
     expected = ds_metric[metricname]
 
     ds_dict_parsed = match_metrics(ds_dict, metric_dict, [metricname])
 
-    assert 'a' in ds_dict_parsed.keys()
-    #TODO this should be factored out into _assert_parsed_ds_dict from the test above
-    xr.testing.assert_allclose(expected, ds_dict_parsed['a'][metricname].reset_coords(drop=True))
+    assert "a" in ds_dict_parsed.keys()
+    # TODO this should be factored out into _assert_parsed_ds_dict from the test above
+    xr.testing.assert_allclose(
+        expected, ds_dict_parsed["a"][metricname].reset_coords(drop=True)
+    )
+
 
 def test_match_metrics_missing_match_attrs():
     """If one of the `match_attrs` is not in the dataset this should error out"""
-    metricname = 'area'
+    metricname = "area"
     ds_a = random_ds()
     ds_a.attrs = {
         "source_id": "a",
     }
     ds_metric = random_ds().isel(time=0).rename({"data": metricname})
     ds_metric.attrs = ds_a.attrs
-    
+
     ds_dict = {"a": ds_a}
     metric_dict = {"something": ds_metric}
-    expected = ds_metric[metricname]
-    with pytest.raises(ValueError, match='Cannot match datasets because at least one of the datasets does not contain all attributes'):
-        ds_dict_parsed = match_metrics(ds_dict, metric_dict, [metricname])
-
-
+    with pytest.raises(
+        ValueError,
+        match="Cannot match datasets because at least one of the datasets does not contain all attributes",
+    ):
+        match_metrics(ds_dict, metric_dict, [metricname])
 
 
 def test_match_metrics_missing_attr():

--- a/xmip/postprocessing.py
+++ b/xmip/postprocessing.py
@@ -4,8 +4,6 @@ import warnings
 
 from typing import List, Mapping
 
-from typing import List, Mapping
-
 import numpy as np
 import xarray as xr
 

--- a/xmip/postprocessing.py
+++ b/xmip/postprocessing.py
@@ -30,13 +30,7 @@ EXACT_ATTRS = [
 
 def _match_attrs(ds_a, ds_b, match_attrs):
     """returns the number of matched attrs between two datasets"""
-    try:
-        n_match = sum([ds_a.attrs[i] == ds_b.attrs[i] for i in match_attrs])
-        return n_match
-    except KeyError:
-        raise ValueError(
-            f"Cannot match datasets because at least one of the datasets does not contain all attributes [{match_attrs}]."
-        )
+    return sum([ds_a.attrs[i] == ds_b.attrs[i] for i in match_attrs])
 
 
 def _match_datasets(ds, ds_dict, match_attrs, pop=True, nomatch="ignore", unique=False):
@@ -74,27 +68,6 @@ def _match_datasets(ds, ds_dict, match_attrs, pop=True, nomatch="ignore", unique
                 f"Invalid input ({nomatch}) for `nomatch`, should be `ignore`, `warn`, or `raise`"
             )
     return datasets
-
-
-def _prune_match_attrs_to_available(
-    match_attrs: List[str], ds_dict: Mapping[str, xr.Dataset]
-) -> List[str]:
-    """prune a set of attrs to only the ones available in every dataset"""
-    missing_match_attrs = []
-    for ma in match_attrs:
-        if all([ma not in ds.attrs.keys() for ds in ds_dict.values()]):
-            missing_match_attrs.append(ma)
-
-    if len(missing_match_attrs) > 0:
-        warnings.warn(
-            f"Match attributes {missing_match_attrs} not found in any of the datasets. \
-        This can happen when several combination functions are used and attributes are removed during merging. \
-        Double check the results."
-        )
-        pruned_match_attrs = [ma for ma in match_attrs if ma not in missing_match_attrs]
-        return pruned_match_attrs
-    else:
-        return match_attrs
 
 
 def combine_datasets(
@@ -181,7 +154,6 @@ def merge_variables(
         A new dict of xr.Datasets with all datasets from `ds_dict`, but with merged variables and adjusted keys.
 
     """
-    # An exact match is only possible if all attrs in `EXACT_ATTRS` are in every dataset
 
     match_attrs = [ma for ma in EXACT_ATTRS if ma not in ["variable_id"]]
 
@@ -609,8 +581,7 @@ def match_metrics(
     match_variables : list
         Data variables of datasets in `metric_dict` to parse.
     match_attrs : list, optional
-        Minimum dataset attributes that need to match, by default ["source_id", "grid_label"].
-        Pass "exact" to only allow exact matches using all required attributes.
+        Minimum dataset attributes that need to match, by default ["source_id", "grid_label"]
     print_statistics : bool, optional
         Option to print statistics about matching, by default False
     dim_length_conflict : str
@@ -623,13 +594,7 @@ def match_metrics(
 
     """
     # metrics should never match the variable
-    exact_attrs_wo_var = [ma for ma in EXACT_ATTRS if ma != "variable_id"]
-
-    # TODO: this naming is a big weird. Basically this here is necessary to still get a 'closest match' on whichever of the full
-    # set of 'exact' attrs are given on each of the datasets
-    pruned_attrs = _prune_match_attrs_to_available(exact_attrs_wo_var, ds_dict)
-    # and this also needs to be true for the metrics of course.
-    pruned_attrs = _prune_match_attrs_to_available(pruned_attrs, metric_dict)
+    exact_attrs_wo_var = [ma for ma in exact_attrs if ma != "variable_id"]
 
     match_variables = _maybe_make_list(match_variables)
 


### PR DESCRIPTION
Recent changes in intake-esm already created a 'member_id' dimension on datasets. This PR makes the xmip equivalent process more flexible (allowing to work with both intake-esm and raw zarr stores) and also fully conforms with the [official reconstruction method](https://docs.google.com/document/d/1h0r8RZr_f3-8egBMMh7aqLwy3snpD6_MrDz1q8n5XUk/edit) (see under "File name template:") including accounting for `sub_experiment_id` (only relevant for DCPP experiments I believe).