### PR TITLE
Improve renaming logic to prevent million warnings

### DIFF
--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -472,19 +472,46 @@ def test_combined_preprocessing_dropped_coords(add_coords, shift):
     assert "bnds" not in ds.coords
 
 
-def test_combined_preprocessing_mislabeled_coords():
-    """Test if the renaming is applied to datavariables and then if they are moved to the coords."""
+def test_rename_mislabeled_coords():
+    """Test if the renaming is applied to datavariables"""
     # create a 2d dataset
-    xlen, ylen, zlen = (10, 5, 1)
-    ds = (
-        create_test_ds("x", "y", "dummy", xlen, ylen, zlen).squeeze().drop_vars("dummy")
-    )
-    ds = ds.assign(depth=5.0)
-    ds.depth.attrs["units"] = "m"  # otherwise pint complains.
+    xlen, ylen, zlen = (10, 5, 3)
+    ds = create_test_ds("x", "y", "z", xlen, ylen, zlen).squeeze()
+    ds["nav_lon"] = ds.lon  # assign longitude as data variable
+    ds = ds.drop_vars(["lon"])
 
-    ds_pp = combined_preprocessing(ds)
-    assert "lev" in ds_pp.coords
-    np.testing.assert_allclose(ds.depth.data, ds_pp.lev.data)
+    ds_pp = rename_cmip6(ds)
+    np.testing.assert_allclose(ds.nav_lon.data, ds_pp.lon.data)
+
+
+def test_duplicate_renamed_coordinates():
+    # create a 2d dataset
+    xlen, ylen, zlen = (10, 5, 3)
+    ds = create_test_ds("x", "y", "lev", xlen, ylen, zlen)
+    ds = ds.drop_vars("lon")  # drop the original longitude
+    # assign two coordinates which should both be renamed according to the renaming dict
+    coord_da_1 = xr.DataArray(np.random.rand(xlen, ylen), dims=["x", "y"])
+    coord_da_2 = xr.DataArray(np.random.rand(xlen, ylen), dims=["x", "y"])
+    ds = ds.assign_coords(longitude=coord_da_1, nav_lon=coord_da_2)
+    ds_pp = rename_cmip6(ds)
+    assert "nav_lon" in ds_pp.coords
+    xr.testing.assert_allclose(
+        ds_pp.lon.reset_coords(drop=True).drop(["x", "y"]), coord_da_1
+    )
+
+
+def test_renamed_coordinate_exists():
+    # create a 2d dataset
+    xlen, ylen, zlen = (10, 5, 3)
+    ds = create_test_ds("x", "y", "lev", xlen, ylen, zlen)
+    # assign two coordinates which should both be renamed according to the renaming dict
+    coord_da = xr.DataArray(np.random.rand(xlen, ylen), dims=["x", "y"])
+    ds = ds.assign_coords(longitude=coord_da)
+
+    ds_pp = rename_cmip6(ds)
+    # make sure the original lon is intact
+    xr.testing.assert_allclose(ds_pp.lon, ds.lon)
+    assert "longitude" in ds_pp
 
 
 def test_preserve_attrs():

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -493,7 +493,12 @@ def test_duplicate_renamed_coordinates():
     coord_da_1 = xr.DataArray(np.random.rand(xlen, ylen), dims=["x", "y"])
     coord_da_2 = xr.DataArray(np.random.rand(xlen, ylen), dims=["x", "y"])
     ds = ds.assign_coords(longitude=coord_da_1, nav_lon=coord_da_2)
-    ds_pp = rename_cmip6(ds)
+    print(ds)
+    with pytest.warns(
+        match="While renaming to target `lon`, more than one candidate was found"
+    ):
+        ds_pp = rename_cmip6(ds)
+
     assert "nav_lon" in ds_pp.coords
     xr.testing.assert_allclose(
         ds_pp.lon.reset_coords(drop=True).drop(["x", "y"]), coord_da_1

--- a/xmip/preprocessing.py
+++ b/xmip/preprocessing.py
@@ -88,10 +88,11 @@ def rename_cmip6(ds, rename_dict=None):
     for target, candidates in rename_dict.items():
         if target not in ds:
             matching_candidates = [ca for ca in candidates if ca in rename_vars]
+            print(matching_candidates)
             if len(matching_candidates) > 0:
-                if len(matching_candidates) > 2:
-                    raise ValueError(
-                        f"While renaming to target {target}, more than one candidate was found [{matching_candidates}]. Renaming {matching_candidates[0]} to {target}. Please double check results."
+                if len(matching_candidates) > 1:
+                    warnings.warn(
+                        f"{cmip6_dataset_id(ds)}:While renaming to target `{target}`, more than one candidate was found {matching_candidates}. Renaming {matching_candidates[0]} to {target}. Please double check results."
                     )
                 ds = ds.rename({matching_candidates[0]: target})
 

--- a/xmip/preprocessing.py
+++ b/xmip/preprocessing.py
@@ -83,7 +83,7 @@ def rename_cmip6(ds, rename_dict=None):
         }
     )
 
-    rename_vars = list(ds.coords) + list(ds.data_vars)
+    rename_vars = list(set(ds.coords) - set(ds.dims)) + list(ds.data_vars)
 
     for target, candidates in rename_dict.items():
         if target not in ds:

--- a/xmip/preprocessing.py
+++ b/xmip/preprocessing.py
@@ -84,11 +84,11 @@ def rename_cmip6(ds, rename_dict=None):
     )
 
     rename_vars = list(set(ds.coords) - set(ds.dims)) + list(ds.data_vars)
+    print(rename_vars)
 
     for target, candidates in rename_dict.items():
         if target not in ds:
             matching_candidates = [ca for ca in candidates if ca in rename_vars]
-            print(matching_candidates)
             if len(matching_candidates) > 0:
                 if len(matching_candidates) > 1:
                     warnings.warn(

--- a/xmip/preprocessing.py
+++ b/xmip/preprocessing.py
@@ -73,7 +73,7 @@ def rename_cmip6(ds, rename_dict=None):
             for target, candidates in rdict.items():
                 if di in candidates:
                     da = da.swap_dims({di: target})
-                    if di in da:
+                    if di in da.variables:
                         da = da.drop_vars(di)
         return da
 

--- a/xmip/preprocessing.py
+++ b/xmip/preprocessing.py
@@ -72,7 +72,7 @@ def rename_cmip6(ds, rename_dict=None):
         for di in da.dims:
             for target, candidates in rdict.items():
                 if di in candidates:
-                    da = da.rename({di: target})
+                    da = da.swap_dims({di: target})
         return da
 
     # first take care of the dims and reconstruct a clean ds

--- a/xmip/preprocessing.py
+++ b/xmip/preprocessing.py
@@ -84,7 +84,7 @@ def rename_cmip6(ds, rename_dict=None):
     )
 
     rename_vars = list(set(ds.coords) - set(ds.dims)) + list(ds.data_vars)
-    print(rename_vars)
+    print(set(rename_vars))
 
     for target, candidates in rename_dict.items():
         if target not in ds:

--- a/xmip/preprocessing.py
+++ b/xmip/preprocessing.py
@@ -73,6 +73,8 @@ def rename_cmip6(ds, rename_dict=None):
             for target, candidates in rdict.items():
                 if di in candidates:
                     da = da.swap_dims({di: target})
+                    if di in da:
+                        da = da.drop_vars(di)
         return da
 
     # first take care of the dims and reconstruct a clean ds
@@ -82,6 +84,7 @@ def rename_cmip6(ds, rename_dict=None):
             for k in list(ds.data_vars) + list(set(ds.coords) - set(ds.dims))
         }
     )
+    print(ds)
 
     rename_vars = list(set(ds.coords) - set(ds.dims)) + list(ds.data_vars)
     print(set(rename_vars))

--- a/xmip/preprocessing.py
+++ b/xmip/preprocessing.py
@@ -60,6 +60,7 @@ def cmip6_renaming_dict():
 def rename_cmip6(ds, rename_dict=None):
     """Homogenizes cmip6 dataasets to common naming"""
     attrs = {k: v for k, v in ds.attrs.items()}
+    ds_id = cmip6_dataset_id(ds)
 
     if rename_dict is None:
         rename_dict = cmip6_renaming_dict()
@@ -93,7 +94,7 @@ def rename_cmip6(ds, rename_dict=None):
             if len(matching_candidates) > 0:
                 if len(matching_candidates) > 1:
                     warnings.warn(
-                        f"{cmip6_dataset_id(ds)}:While renaming to target `{target}`, more than one candidate was found {matching_candidates}. Renaming {matching_candidates[0]} to {target}. Please double check results."
+                        f"{ds_id}:While renaming to target `{target}`, more than one candidate was found {matching_candidates}. Renaming {matching_candidates[0]} to {target}. Please double check results."
                     )
                 ds = ds.rename({matching_candidates[0]: target})
 

--- a/xmip/preprocessing.py
+++ b/xmip/preprocessing.py
@@ -73,7 +73,7 @@ def rename_cmip6(ds, rename_dict=None):
             for target, candidates in rdict.items():
                 if di in candidates:
                     da = da.swap_dims({di: target})
-                    if di in da.variables:
+                    if di in da.coords:
                         da = da.drop_vars(di)
         return da
 

--- a/xmip/preprocessing.py
+++ b/xmip/preprocessing.py
@@ -84,10 +84,8 @@ def rename_cmip6(ds, rename_dict=None):
             for k in list(ds.data_vars) + list(set(ds.coords) - set(ds.dims))
         }
     )
-    print(ds)
 
-    rename_vars = list(set(ds.coords) - set(ds.dims)) + list(ds.data_vars)
-    print(set(rename_vars))
+    rename_vars = list(set(ds.variables) - set(ds.dims))
 
     for target, candidates in rename_dict.items():
         if target not in ds:


### PR DESCRIPTION
This is my attempt on a backwards compatible refactor of the renaming logic. The previous logic relied on a [janky try-except silent failure](https://github.com/jbusecke/xMIP/blob/aba65dac9aebf26f0b164b7e8568a077ccef8759/xmip/preprocessing.py#L102-L107).

I simplified the logic a bit. In case there are multiple renaming candidates, the first match according to the values in the rename_dict will be chosen. If the target name already exists, nothing happens. I will test this on real datasets, and see if the warnings are reduced. Otherwise Ill have to consider not raising a warning at all?