### PR TITLE
Assume longitude is cyclic in `_interp_nominal_lon`

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -2,6 +2,21 @@
 
 What's New
 ===========
+.. _whats-new.0.8.0:
+
+v0.8.0 (unreleased)
+-------------------
+
+Internal Changes
+~~~~~~~~~~~~~~~~
+- Add `longitude_bnds` and `latitude_bnds` to `cmip_renaming_dict` (:pull:`300`). By `Joran Angevaare <https://github.com/JoranAngevaare>`
+- Updated pre-commit linting to use ruff (:pull:`359`). By `Julius Busecke <https://github.com/jbusecke>`
+- Added 'nvertices' -> 'vertex' to renaming preprocessor (:pull:`357`). By `Julius Busecke <https://github.com/jbusecke>`
+
+Bugfixes
+~~~~~~~~
+- Fixed cyclic interpolation in `_interp_nominal_lon` (:issue:`295`, :pull:`296`). By `Joran Angevaare <https://github.com/JoranAngevaare>`
+
 .. _whats-new.0.7.2:
 
 v0.7.2 (unreleased)

--- a/xmip/preprocessing.py
+++ b/xmip/preprocessing.py
@@ -138,7 +138,7 @@ def _interp_nominal_lon(lon_1d):
     x = np.arange(len(lon_1d))
     idx = np.isnan(lon_1d)
     # Assume that longitudes are cyclic
-    ret =  np.interp(x, x[~idx], lon_1d[~idx], period=len(lon_1d))
+    ret = np.interp(x, x[~idx], lon_1d[~idx], period=len(lon_1d))
     return ret
 
 

--- a/xmip/preprocessing.py
+++ b/xmip/preprocessing.py
@@ -137,9 +137,8 @@ def broadcast_lonlat(ds, verbose=True):
 def _interp_nominal_lon(lon_1d):
     x = np.arange(len(lon_1d))
     idx = np.isnan(lon_1d)
-    # Assume that longitudes are cyclic
-    ret = np.interp(x, x[~idx], lon_1d[~idx], period=len(lon_1d))
-    return ret
+    # Assume that longitudes are cyclic (i.e. that the period equals the length of lon)
+    return np.interp(x, x[~idx], lon_1d[~idx], period=len(lon_1d))
 
 
 def replace_x_y_nominal_lat_lon(ds):

--- a/xmip/preprocessing.py
+++ b/xmip/preprocessing.py
@@ -137,7 +137,9 @@ def broadcast_lonlat(ds, verbose=True):
 def _interp_nominal_lon(lon_1d):
     x = np.arange(len(lon_1d))
     idx = np.isnan(lon_1d)
-    return np.interp(x, x[~idx], lon_1d[~idx], period=360)
+    # Assume that longitudes are cyclic
+    ret =  np.interp(x, x[~idx], lon_1d[~idx], period=len(lon_1d))
+    return ret
 
 
 def replace_x_y_nominal_lat_lon(ds):


### PR DESCRIPTION
A potential solution to #295. Instead of assuming there are a cyclic 360 datapoints (in longitude), assume that the set is cyclic with however many datapoins in there are in the longitude coordinate.

## Example
<details></summary>Setup</summary>

```python

# Basic imports
import numpy as np
import xarray as xr
from xmip.preprocessing import promote_empty_dims, replace_x_y_nominal_lat_lon, rename_cmip6, correct_coordinates, broadcast_lonlat
import matplotlib.pyplot as plt
import sys
import numpy, xarray, xmip
message = f'{sys.platform}\n{sys.version}'
for b in 'numpy xarray xmip'.split():
    message += f'\n\t{b}=={locals().get(b).__version__}'
print(message)

# Totally arbitrary data
lon=np.linspace(0,360, 513)[:-1]
lat=np.linspace(-90,90, 181)[:-1]
time=np.arange(1)
data=np.arange(len(lat)*len(lon)*len(time)).reshape(len(time), len(lat), len(lon))*lon

# Add some NaN values just as an example
data[:, :, len(lon)//2+30: len(lon)//2+50] = np.nan

ds_dummy = xr.Dataset(
    data_vars = dict(var=(('time','lat', 'lon'), data,)),
    coords = dict(time=time, lon=lon, lat=lat,),
    attrs=dict(source_id='bla'))


def setup_plt():
    """use cartopy to make a "map" for the dummy data. If cartopy is not installed, do nothing"""
    try:
        import cartopy.crs as ccrs
    except (ImportError, ModuleNotFoundError):
        return
    plt.gcf().add_subplot(projection=ccrs.PlateCarree(central_longitude=0.0,))
    ax = plt.gca()

    ax.coastlines()
    ax.gridlines(draw_labels=True)

def recast(data_set):
    ds = rename_cmip6(data_set)
    ds = promote_empty_dims(ds)
    ds = broadcast_lonlat(ds)
    ds = replace_x_y_nominal_lat_lon(ds)
    return ds
```
which gives
```
linux
3.8.16 (default, Mar  2 2023, 03:21:46) 
[GCC 11.2.0]
	numpy==1.24.3
	xarray==2023.1.0
	xmip==0.7.1
```
</details>

### Starting point:
```python
setup_plt()
ds_dummy['var'].isel(time=0).plot(cbar_kwargs=dict(orientation='horizontal'))
```
![image](https://github.com/jbusecke/xMIP/assets/22295914/275aec78-4722-4823-9062-b00eca9729e2)


### Broken example:
```python
setup_plt()
ds_dum_recast = recast(ds_dummy)
replace_x_y_nominal_lat_lon(ds_dum_recast)['var'].isel(time=0).plot(cbar_kwargs=dict(orientation='horizontal'),)
```
![image](https://github.com/jbusecke/xMIP/assets/22295914/516dc251-1d62-4178-93dc-02902136903b)

### Patch:

```python
def _interp_nominal_lon_new(lon_1d):
    print('Using altered version')
    x = np.arange(len(lon_1d))
    idx = np.isnan(lon_1d)
    # TODO assume that longitudes are cyclic (i.e., don't)
    ret = np.interp(x, x[~idx], lon_1d[~idx], period=len(lon_1d))
    return ret

xmip.preprocessing._interp_nominal_lon = _interp_nominal_lon_new
setup_plt()
ds_dum_recast = recast(ds_dummy)
ds_dum_recast['var'].isel(time=0).plot(cbar_kwargs=dict(orientation='horizontal', extend='both'),)
```

![image](https://github.com/jbusecke/xMIP/assets/22295914/8a1a74e0-bc8c-4f5f-8555-f06cd6b32368)
