### PR TITLE
Add `longitude_bnds` and `latitude_bnds` to `cmip_renaming_dict`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,7 @@ jobs:
         run: |
           pytest -n auto --cov=./ --cov-report=xml --ignore=tests/test_preprocessing_cloud.py
       - name: Upload code coverage to Codecov
-        uses: codecov/codecov-action@v3.1.1
+        uses: codecov/codecov-action@v3.1.3
         with:
           file: ./coverage.xml
           flags: unittests
@@ -96,7 +96,7 @@ jobs:
         run: |
           pytest -n auto --cov=./ --cov-report=xml --ignore=tests/test_preprocessing_cloud.py
       - name: Upload code coverage to Codecov
-        uses: codecov/codecov-action@v3.1.1
+        uses: codecov/codecov-action@v3.1.3
         with:
           file: ./coverage.xml
           flags: unittests
@@ -142,7 +142,7 @@ jobs:
         run: |
           pytest -n auto --cov=./ --cov-report=xml --ignore=tests/test_preprocessing_cloud.py
       - name: Upload code coverage to Codecov
-        uses: codecov/codecov-action@v3.1.1
+        uses: codecov/codecov-action@v3.1.3
         with:
           file: ./coverage.xml
           flags: unittests

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -10,6 +10,7 @@ v0.7.2 (unreleased)
 Internal Changes
 ~~~~~~~~~~~~~~~~
 - Added PR template (:pull:`304`). By `Julius Busecke <https://github.com/jbusecke>`
+- Add `longitude_bnds` and `latitude_bnds` to `cmip_renaming_dict` (:pull:`300`). By `Joran Angevaare <https://github.com/JoranAngevaare>`
 
 
 .. _whats-new.0.7.0:

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -2,9 +2,19 @@
 
 What's New
 ===========
+.. _whats-new.0.8.0:
+
+v0.8.0 (unreleased)
+-------------------
+
+Internal Changes
+~~~~~~~~~~~~~~~~
+- Add `longitude_bnds` and `latitude_bnds` to `cmip_renaming_dict` (:pull:`300`). By `Joran Angevaare <https://github.com/JoranAngevaare>`
+
+
 .. _whats-new.0.7.2:
 
-v0.7.2 (unreleased)
+v0.7.3 (unreleased)
 -------------------
 
 Internal Changes

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -12,7 +12,6 @@ Internal Changes
 - Added PR template (:pull:`304`). By `Julius Busecke <https://github.com/jbusecke>`
 - Add `longitude_bnds` and `latitude_bnds` to `cmip_renaming_dict` (:pull:`300`). By `Joran Angevaare <https://github.com/JoranAngevaare>`
 
-
 .. _whats-new.0.7.0:
 
 v0.7.0 (2023/01/03)

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -218,7 +218,13 @@ def test_correct_coordinates(coord):
 
 
 @pytest.mark.parametrize(
-    "bad_coord", [v for values in cmip6_renaming_dict().values() for v in values]
+    "bad_coord",
+    [
+        v
+        for values in cmip6_renaming_dict().values()
+        for v in values
+        if v not in cmip6_renaming_dict().keys()
+    ],
 )
 def test_renamed_coordinates(bad_coord):
     xlen, ylen, zlen = (10, 5, 6)

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -217,6 +217,20 @@ def test_correct_coordinates(coord):
     assert coord in list(ds_corrected.coords)
 
 
+@pytest.mark.parametrize(
+    'bad_coord',
+        [v for values in cmip6_renaming_dict().values() for v in values]
+)
+def test_renamed_coordinates(bad_coord):
+    xlen, ylen, zlen = (10, 5, 6)
+    ds = create_test_ds("xx", "yy", "zz", xlen, ylen, zlen)
+    # set a new variable which we want to rename
+    ds = ds.assign({bad_coord: ds.test})
+
+    ds_corrected = correct_coordinates(ds)
+    assert bad_coord not in list(ds_corrected.coords)
+
+
 def test_parse_lon_lat_bounds():
     lon = np.arange(0, 10)
     lat = np.arange(20, 30)

--- a/xmip/drift_removal.py
+++ b/xmip/drift_removal.py
@@ -214,7 +214,7 @@ def calculate_drift(
         if len(reference_cut.time) < trend_years * 12:
             if compute_short_trends:
                 warnings.warn(
-                    f"reference dataset does not have the full {trend_years} years to calculate trend. Using {int(len(reference_cut.time)/12)} years only"
+                    f"reference dataset does not have the full {trend_years} years to calculate trend. Using {int(len(reference_cut.time) / 12)} years only"
                 )
             else:
                 raise RuntimeError(

--- a/xmip/preprocessing.py
+++ b/xmip/preprocessing.py
@@ -44,6 +44,7 @@ def cmip6_renaming_dict():
             "lon_bnds",
             "x_bnds",
             "vertices_longitude",
+            'longitude_bnds',
         ],
         "lat_bounds": [
             "bounds_lat",
@@ -51,6 +52,7 @@ def cmip6_renaming_dict():
             "lat_bnds",
             "y_bnds",
             "vertices_latitude",
+            'latitude_bnds',
         ],
         "time_bounds": ["time_bnds"],
     }

--- a/xmip/preprocessing.py
+++ b/xmip/preprocessing.py
@@ -27,7 +27,7 @@ def cmip6_renaming_dict():
         "x": ["i", "ni", "xh", "nlon"],
         "y": ["j", "nj", "yh", "nlat"],
         "lev": ["deptht", "olevel", "zlev", "olev", "depth"],
-        "bnds": ["axis_nbounds", "d2"],
+        "bnds": ["bnds", "axis_nbounds", "d2"],
         "vertex": ["vertex", "nvertex", "vertices"],
         # coordinate labels
         "lon": ["longitude", "nav_lon"],

--- a/xmip/preprocessing.py
+++ b/xmip/preprocessing.py
@@ -44,7 +44,7 @@ def cmip6_renaming_dict():
             "lon_bnds",
             "x_bnds",
             "vertices_longitude",
-            'longitude_bnds',
+            "longitude_bnds",
         ],
         "lat_bounds": [
             "bounds_lat",
@@ -52,7 +52,7 @@ def cmip6_renaming_dict():
             "lat_bnds",
             "y_bnds",
             "vertices_latitude",
-            'latitude_bnds',
+            "latitude_bnds",
         ],
         "time_bounds": ["time_bnds"],
     }

--- a/xmip/preprocessing.py
+++ b/xmip/preprocessing.py
@@ -27,7 +27,7 @@ def cmip6_renaming_dict():
         "x": ["i", "ni", "xh", "nlon"],
         "y": ["j", "nj", "yh", "nlat"],
         "lev": ["deptht", "olevel", "zlev", "olev", "depth"],
-        "bnds": ["bnds", "axis_nbounds", "d2"],
+        "bnds": ["axis_nbounds", "d2"],
         "vertex": ["vertex", "nvertex", "vertices"],
         # coordinate labels
         "lon": ["longitude", "nav_lon"],


### PR DESCRIPTION
Add `longitude_bnds` and `latitude_bnds` to `cmip_renaming_dict`, this allows renaming for example renaming bounds for `'ScenarioMIP.UA.MCM-UA-1-0.ssp585.r1i1p1f2.Amon.gn.none.tas'` .

 - [x] Tests added
 - [x] Passes `pre-commit run --all-files`
 - [x] Passes `pytest`
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
 
