### PR TITLE
Fix deprecated micromamba action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Create conda environment
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/setup-micromamba@v1.4.2
         with:
           cache-downloads: true
           cache-env: true


### PR DESCRIPTION
Got [this](https://github.com/jbusecke/xMIP/actions/runs/5144754009/jobs/9433780261#step:3:14) warning and am following the suggested update here.