### PR TITLE
Expose drop_duplicate_grid_labels in the public API

### DIFF
--- a/xmip/postprocessing.py
+++ b/xmip/postprocessing.py
@@ -352,12 +352,10 @@ def _pick_grid_label(ds_list, preferred_grid_label):
         return ds_list[0]
 
 
-def _drop_duplicate_grid_labels(ddict, preferred_grid_label):
+def drop_duplicate_grid_labels(ddict, preferred_grid_label):
     """Eliminate multiple grid labels for the same dataset, by dropping multiples
     with a preference for `preferred_grid_label`"""
-    match_attrs = [ma for ma in EXACT_ATTRS if ma not in ["version", "grid_label"]] + [
-        "variable_id"
-    ]
+    match_attrs = [ma for ma in EXACT_ATTRS if ma not in ["version", "grid_label"]]
     return combine_datasets(
         ddict,
         _pick_grid_label,
@@ -521,7 +519,7 @@ def interpolate_grid_label(
     merge_kwargs.setdefault("combine_attrs", "drop_conflicts")
 
     # first drop the datasets that might have both the target and another grid_label present
-    ds_dict = _drop_duplicate_grid_labels(ds_dict, target_grid_label)
+    ds_dict = drop_duplicate_grid_labels(ds_dict, target_grid_label)
 
     return combine_datasets(
         ds_dict,


### PR DESCRIPTION
- [ ] Write a test that the combine func never returns duplicate match_attrs. Before this fix keys from drop_duplicate_grid_labels would have variable_id in there twice!

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxxx
 - [ ] Tests added
 - [ ] Passes `pre-commit run --all-files`
 - [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
 - [ ] New functions/methods are listed in `api.rst`
