### PR TITLE
Test interp nominal lon

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,6 +21,10 @@ authors:
   given-names: "Markus"
   orcid: "https://orcid.org/0000-0001-7464-7075"
   affiliation: "Universität Hamburg, Germany"
+- family-names: "Angevaare"
+  given-names: "Joran J. R."
+  orchid: "https://orcid.org/0000-0003-3392-8123"
+  affiliation: "KNMI"
 
 title: "xMIP"
 url: "https://github.com/jbusecke/xMIP"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
   orcid: "https://orcid.org/0000-0002-1660-7822"
 - family-names: "Nicholas"
   given-names: "Thomas"
-  orcid: "0000-0002-2176-0530
+  orcid: "https://orcid.org/0000-0002-2176-0530"
 - family-names: "Magin"
   given-names: "Justus"
   orcid: "https://orcid.org/0000-0002-4254-8002"
@@ -23,7 +23,7 @@ authors:
   affiliation: "Universität Hamburg, Germany"
 - family-names: "Angevaare"
   given-names: "Joran J. R."
-  orchid: "https://orcid.org/0000-0003-3392-8123"
+  orcid: "https://orcid.org/0000-0003-3392-8123"
   affiliation: "KNMI"
 
 title: "xMIP"

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -243,7 +243,7 @@ class TestReplaceXYNominalLatLon(TestCase):
                 f"Cannot work with changed format of inputdata {accepted_differences_between_lon_coords}"
             )
         diff_pars_lons = np.unique(np.diff(lons_parsed))
-        # assert False, diff_pars_lons
+
         return diff_pars_lons in accepted_differences_between_lon_coords
 
 

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -201,7 +201,7 @@ class TestReplaceXYNominalLatLon:
     def test_old_fails(self):
         lons = self._get_dummy_longitude()
         lons_parsed = self._interp_nominal_lon_old(lons)
-        assert not self._lons_parsed_make_sense(
+        assert self._lons_parsed_make_sense(
             lons, lons_parsed
         ), "Parsed lons should be gibberish, but somehow the old implementation also works?"
 

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -227,9 +227,7 @@ def test_interp_nominal_lon():
 
     lons = _get_dummy_longitude()
     lons_parsed = _interp_nominal_lon(lons)
-    assert _lons_parsed_make_sense(
-        lons, lons_parsed
-    ), "Parsed lons after the fix of #296 are still bad?"
+    assert _lons_parsed_make_sense(lons, lons_parsed)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -217,7 +217,6 @@ class TestReplaceXYNominalLatLon(TestCase):
         lon = np.linspace(0, 360, 513)[:-1]
 
         # Add some NaN values just as an example
-        # lon[:, :, len(lon)//2+30: len(lon)//2+50] = np.nan
         lon[2 + 30 : len(lon) // 2 + 50] = np.nan
         return lon
 

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -201,16 +201,16 @@ class TestReplaceXYNominalLatLon:
     def test_old_fails(self):
         lons = self._get_dummy_longitude()
         lons_parsed = self._interp_nominal_lon_old(lons)
-        if self._lons_parsed_make_sense(lons, lons_parsed):
-            raise ValueError(
-                "Parsed lons should be gibberish, but somehow the old implementation also works?"
-            )
+        assert not self._lons_parsed_make_sense(
+            lons, lons_parsed
+        ), "Parsed lons should be gibberish, but somehow the old implementation also works?"
 
     def test_new_works(self):
         lons = self._get_dummy_longitude()
         lons_parsed = _interp_nominal_lon(lons)
-        if not self._lons_parsed_make_sense(lons, lons_parsed):
-            raise ValueError("Parsed lons after the fix of #296 are still bad?")
+        assert self._lons_parsed_make_sense(
+            lons, lons_parsed
+        ), "Parsed lons after the fix of #296 are still bad?"
 
     @staticmethod
     def _get_dummy_longitude() -> np.ndarray:

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -198,29 +198,27 @@ class TestReplaceXYNominalLatLon(TestCase):
     Reproduce the issue as in https://github.com/jbusecke/xMIP/issues/295 and assert that the fix
     of https://github.com/jbusecke/xMIP/pull/296 does the job
     """
-    
-    
+
     def test_old_fails(self):
         lons = self._get_dummy_longitude()
         lons_parsed = self._interp_nominal_lon_old(lons)
         with self.assertRaises(ValueError):
             if not self._lons_parsed_make_sense(lons, lons_parsed):
-                raise ValueError('Parsed lons are gibberish')
-    
+                raise ValueError("Parsed lons are gibberish")
+
     def test_new_works(self):
         lons = self._get_dummy_longitude()
         lons_parsed = _interp_nominal_lon(lons)
         self.assertTrue(self._lons_parsed_make_sense(lons, lons_parsed))
-        
-    
+
     @staticmethod
-    def _get_dummy_longitude()->np.ndarray:
+    def _get_dummy_longitude() -> np.ndarray:
         # Totally arbitrary data (although len(lon) has to be > 360 to see the issue)
-        lon=np.linspace(0,360, 513)[:-1]
-       
+        lon = np.linspace(0, 360, 513)[:-1]
+
         # Add some NaN values just as an example
         # lon[:, :, len(lon)//2+30: len(lon)//2+50] = np.nan
-        lon[2+30: len(lon)//2+50] = np.nan
+        lon[2 + 30 : len(lon) // 2 + 50] = np.nan
         return lon
 
     @staticmethod
@@ -228,16 +226,22 @@ class TestReplaceXYNominalLatLon(TestCase):
         x = np.arange(len(lon_1d))
         idx = np.isnan(lon_1d)
         return np.interp(x, x[~idx], lon_1d[~idx], period=360)
-    
-    def _lons_parsed_make_sense(self, input_lons:np.ndarray, lons_parsed:np.ndarray)-> bool:
+
+    def _lons_parsed_make_sense(
+        self, input_lons: np.ndarray, lons_parsed: np.ndarray
+    ) -> bool:
         """
         Check if the parsed longitudes make sense.
-        
+
         Since we know that the input-lons are all monotonically increasing, the parsed lons should also do that.
         """
-        accepted_differences_between_lon_coords =  [np.array([1, np.nan]), np.ones(1)]
-        if len(accepted_differences_between_lon_coords := np.unique(np.diff(input_lons))) not in [1,2]:
-            raise RuntimeError(f'Cannot work with changed format of inputdata {accepted_differences_between_lon_coords}')
+        accepted_differences_between_lon_coords = [np.array([1, np.nan]), np.ones(1)]
+        if len(
+            accepted_differences_between_lon_coords := np.unique(np.diff(input_lons))
+        ) not in [1, 2]:
+            raise RuntimeError(
+                f"Cannot work with changed format of inputdata {accepted_differences_between_lon_coords}"
+            )
         diff_pars_lons = np.unique(np.diff(lons_parsed))
         # assert False, diff_pars_lons
         return diff_pars_lons in accepted_differences_between_lon_coords

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -234,10 +234,8 @@ class TestReplaceXYNominalLatLon(TestCase):
 
         Since we know that the input-lons are all monotonically increasing, the parsed lons should also do that.
         """
-        accepted_differences_between_lon_coords = [np.array([1, np.nan]), np.ones(1)]
-        if len(
-            accepted_differences_between_lon_coords := np.unique(np.diff(input_lons))
-        ) not in [1, 2]:
+        accepted_differences_between_lon_coords = np.unique(np.diff(input_lons))
+        if len(accepted_differences_between_lon_coords) not in [1, 2]:
             raise RuntimeError(
                 f"Cannot work with changed format of inputdata {accepted_differences_between_lon_coords}"
             )

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -20,7 +20,9 @@ from xmip.preprocessing import (
     rename_cmip6,
     replace_x_y_nominal_lat_lon,
     sort_vertex_order,
+    _interp_nominal_lon,
 )
+from unittest import TestCase
 
 
 def create_test_ds(xname, yname, zname, xlen, ylen, zlen):
@@ -189,6 +191,56 @@ def test_replace_x_y_nominal_lat_lon(dask, nans):
     assert len(replaced_ds.lat.shape) == 2
     assert set(replaced_ds.lon.dims) == set(["x", "y"])
     assert set(replaced_ds.lat.dims) == set(["x", "y"])
+
+
+class TestReplaceXYNominalLatLon(TestCase):
+    """
+    Reproduce the issue as in https://github.com/jbusecke/xMIP/issues/295 and assert that the fix
+    of https://github.com/jbusecke/xMIP/pull/296 does the job
+    """
+    
+    
+    def test_old_fails(self):
+        lons = self._get_dummy_longitude()
+        lons_parsed = self._interp_nominal_lon_old(lons)
+        with self.assertRaises(ValueError):
+            if not self._lons_parsed_make_sense(lons, lons_parsed):
+                raise ValueError('Parsed lons are gibberish')
+    
+    def test_new_works(self):
+        lons = self._get_dummy_longitude()
+        lons_parsed = _interp_nominal_lon(lons)
+        self.assertTrue(self._lons_parsed_make_sense(lons, lons_parsed))
+        
+    
+    @staticmethod
+    def _get_dummy_longitude()->np.ndarray:
+        # Totally arbitrary data (although len(lon) has to be > 360 to see the issue)
+        lon=np.linspace(0,360, 513)[:-1]
+       
+        # Add some NaN values just as an example
+        # lon[:, :, len(lon)//2+30: len(lon)//2+50] = np.nan
+        lon[2+30: len(lon)//2+50] = np.nan
+        return lon
+
+    @staticmethod
+    def _interp_nominal_lon_old(lon_1d: np.ndarray) -> np.ndarray:
+        x = np.arange(len(lon_1d))
+        idx = np.isnan(lon_1d)
+        return np.interp(x, x[~idx], lon_1d[~idx], period=360)
+    
+    def _lons_parsed_make_sense(self, input_lons:np.ndarray, lons_parsed:np.ndarray)-> bool:
+        """
+        Check if the parsed longitudes make sense.
+        
+        Since we know that the input-lons are all monotonically increasing, the parsed lons should also do that.
+        """
+        accepted_differences_between_lon_coords =  [np.array([1, np.nan]), np.ones(1)]
+        if len(accepted_differences_between_lon_coords := np.unique(np.diff(input_lons))) not in [1,2]:
+            raise RuntimeError(f'Cannot work with changed format of inputdata {accepted_differences_between_lon_coords}')
+        diff_pars_lons = np.unique(np.diff(lons_parsed))
+        # assert False, diff_pars_lons
+        return diff_pars_lons in accepted_differences_between_lon_coords
 
 
 @pytest.mark.parametrize(

--- a/xmip/preprocessing.py
+++ b/xmip/preprocessing.py
@@ -137,7 +137,7 @@ def broadcast_lonlat(ds, verbose=True):
     return ds
 
 
-def _interp_nominal_lon(lon_1d):
+def _interp_nominal_lon(lon_1d: np.ndarray) -> np.ndarray:
     x = np.arange(len(lon_1d))
     idx = np.isnan(lon_1d)
     # Assume that longitudes are cyclic (i.e. that the period equals the length of lon)


### PR DESCRIPTION
## Fix test for `_interp_nominal_lon`
This PR is some leftover work from #296 (and #300)
-  I've added a dummy test - which is a slimmed down version of the example issue in #295.
- Add type-hints to #296
- Fix #358

### PR checks
 - [x] Closes #295, #358
 - [x] Tests added
 - [x] Passes `pre-commit run --all-files`
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
 - [x] New functions/methods are listed in `api.rst`
