### PR TITLE
Fix formatting `whats-new.rst` for doc-building

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
   orcid: "https://orcid.org/0000-0002-1660-7822"
 - family-names: "Nicholas"
   given-names: "Thomas"
-  orcid: "0000-0002-2176-0530
+  orcid: "0000-0002-2176-0530"
 - family-names: "Magin"
   given-names: "Justus"
   orcid: "https://orcid.org/0000-0002-4254-8002"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,8 +70,8 @@ exclude_patterns = ["_build", "**.ipynb_checkpoints", "Thumbs.db", ".DS_Store"]
 
 # link to github issues
 extlinks = {
-    "issue": ("https://github.com/jbusecke/xmip/issues/%s", "GH#"),
-    "pull": ("https://github.com/jbusecke/xmip/issues/%s", "GH#"),
+    "issue": ("https://github.com/jbusecke/xmip/issues/%s", "GH#%s"),
+    "pull": ("https://github.com/jbusecke/xmip/pull/%s", "GH#%s"),
 }
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -18,7 +18,7 @@ Internal Changes
 Bugfixes
 ~~~~~~~~
 - Fixed cyclic interpolation in `_interp_nominal_lon` (:issue:`295`, :pull:`296`). By `Joran Angevaare <https://github.com/JoranAngevaare>`_
-- Fix formatting `whatsnew.rst` for doc-building (:pull:`366`). By `Joran Angevaare <https://github.com/JoranAngevaare>`_
+- Fix formatting `whats-new.rst` for doc-building (:pull:`366`). By `Joran Angevaare <https://github.com/JoranAngevaare>`_
 
 .. _whats-new.0.7.2:
 

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -9,15 +9,15 @@ v0.8.0 (unreleased)
 
 Internal Changes
 ~~~~~~~~~~~~~~~~
-- Add `longitude_bnds` and `latitude_bnds` to `cmip_renaming_dict` (:pull:`300`). By `Joran Angevaare <https://github.com/JoranAngevaare>`
-- Updated pre-commit linting to use ruff (:pull:`359`). By `Julius Busecke <https://github.com/jbusecke>`
-- Modernized packaging workflow, that runs on each PR (:pull:`361`). By `Julius Busecke <https://github.com/jbusecke>`
-- Added 'nvertices' -> 'vertex' to renaming preprocessor (:pull:`357`). By `Julius Busecke <https://github.com/jbusecke>`
-- Updated mamba CI + testing py311/py312 (:issue:`360`, :pull:`362`). By `Julius Busecke <https://github.com/jbusecke>`
+- Add `longitude_bnds` and `latitude_bnds` to `cmip_renaming_dict` (:pull:300). By `Joran Angevaare <https://github.com/JoranAngevaare>`
+- Updated pre-commit linting to use ruff (:pull:359). By `Julius Busecke <https://github.com/jbusecke>`
+- Modernized packaging workflow, that runs on each PR (:pull:361). By `Julius Busecke <https://github.com/jbusecke>`
+- Added 'nvertices' -> 'vertex' to renaming preprocessor (:pull:357). By `Julius Busecke <https://github.com/jbusecke>`
+- Updated mamba CI + testing py311/py312 (:issue:360, :pull:362). By `Julius Busecke <https://github.com/jbusecke>`
 
 Bugfixes
 ~~~~~~~~
-- Fixed cyclic interpolation in `_interp_nominal_lon` (:issue:`295`, :pull:`296`). By `Joran Angevaare <https://github.com/JoranAngevaare>`
+- Fixed cyclic interpolation in `_interp_nominal_lon` (:issue:295, :pull:296). By `Joran Angevaare <https://github.com/JoranAngevaare>`
 
 .. _whats-new.0.7.2:
 
@@ -26,8 +26,8 @@ v0.7.3 (unreleased)
 
 Internal Changes
 ~~~~~~~~~~~~~~~~
-- Added PR template (:pull:`304`). By `Julius Busecke <https://github.com/jbusecke>`
-- Add `longitude_bnds` and `latitude_bnds` to `cmip_renaming_dict` (:pull:`300`). By `Joran Angevaare <https://github.com/JoranAngevaare>`
+- Added PR template (:pull:304). By `Julius Busecke <https://github.com/jbusecke>`
+- Add `longitude_bnds` and `latitude_bnds` to `cmip_renaming_dict` (:pull:300). By `Joran Angevaare <https://github.com/JoranAngevaare>`
 
 .. _whats-new.0.7.0:
 
@@ -36,40 +36,40 @@ v0.7.0 (2023/01/03)
 
 New Features
 ~~~~~~~~~~~~
-- :py:func:`~xmip.postprocessing.match_metrics` Now allows more flexible metric matching (accepting e.g. already merged members) + better error for missing match_attrs (:pull:`275`). By `Julius Busecke <https://github.com/jbusecke>`_
-- Postprocessing functions can now easily be nested on top of each other (:pull:`187`). By `Julius Busecke <https://github.com/jbusecke>`_
+- :py:func:`~xmip.postprocessing.match_metrics` Now allows more flexible metric matching (accepting e.g. already merged members) + better error for missing match_attrs (:pull:275). By `Julius Busecke <https://github.com/jbusecke>`_
+- Postprocessing functions can now easily be nested on top of each other (:pull:187). By `Julius Busecke <https://github.com/jbusecke>`_
 
 
 Breaking Changes
 ~~~~~~~~~~~~~~~~
-- Requires xarray>=0.17.0 and drops support for python 3.6 (:pull:`170`, :pull:`173`). By `Julius Busecke <https://github.com/jbusecke>`_
-- :py:func:`~xmip.utils.cmip6_dataset_id` not includes the attribute `variable_id` (:pull:`166`) By `Julius Busecke <https://github.com/jbusecke>`_
-- Dropped support for python 3.7 (:pull:`268`, :issue:`267`). By `Julius Busecke <https://github.com/jbusecke>`_
+- Requires xarray>=0.17.0 and drops support for python 3.6 (:pull:170, :pull:173). By `Julius Busecke <https://github.com/jbusecke>`_
+- :py:func:`~xmip.utils.cmip6_dataset_id` not includes the attribute `variable_id` (:pull:166) By `Julius Busecke <https://github.com/jbusecke>`_
+- Dropped support for python 3.7 (:pull:268, :issue:267). By `Julius Busecke <https://github.com/jbusecke>`_
 
 Internal Changes
 ~~~~~~~~~~~~~~~~
 
-- Unit correction logic now uses pint-xarray under the hood (:pull:`160`, :issue:`31`).
+- Unit correction logic now uses pint-xarray under the hood (:pull:160, :issue:31).
 By `Tom Nicholas <https://github.com/TomNicholas>`_ and `Julius Busecke <https://github.com/jbusecke>`_
 
-- License changed to Apache-2.0 (:pull:`272`, :issue:`256`). By `Julius Busecke <https://github.com/jbusecke>`_
+- License changed to Apache-2.0 (:pull:272, :issue:256). By `Julius Busecke <https://github.com/jbusecke>`_
 
 Bugfixes
 ~~~~~~~~
-- :py:func:`~xmip.postprocessing.concat_members` now accepts datasets which already have 'member_id' as a dimension (maintain compatibility with recent intake-esm changes) (:pull:`277`). By `Julius Busecke <https://github.com/jbusecke>`_
+- :py:func:`~xmip.postprocessing.concat_members` now accepts datasets which already have 'member_id' as a dimension (maintain compatibility with recent intake-esm changes) (:pull:277). By `Julius Busecke <https://github.com/jbusecke>`_
 
-- :py:func:`~xmip.postprocessing.match_metrics` now accepts single variables as str input (:issue:`229`, :pull:`245`). By `Julius Busecke <https://github.com/jbusecke>`_
+- :py:func:`~xmip.postprocessing.match_metrics` now accepts single variables as str input (:issue:229, :pull:245). By `Julius Busecke <https://github.com/jbusecke>`_
 
-- :py:func:`~xmip.postprocessing.concat_members` now returns a dataset with labelled `member_id` dimension (:issue:`196` , :pull:`197`). By `Julius Busecke <https://github.com/jbusecke>`_
+- :py:func:`~xmip.postprocessing.concat_members` now returns a dataset with labelled `member_id` dimension (:issue:196 , :pull:197). By `Julius Busecke <https://github.com/jbusecke>`_
 
-- Fixes incompatibility with upstream changes in xarray>=0.19.0 (:issue:`173`, :pull:`174`). By `Julius Busecke <https://github.com/jbusecke>`_
+- Fixes incompatibility with upstream changes in xarray>=0.19.0 (:issue:173, :pull:174). By `Julius Busecke <https://github.com/jbusecke>`_
 
-- :py:func:`~xmip.drift_removal.match_and_remove_drift` does now work with chunked (dask powered) datasets (:pull:`164`).By `Julius Busecke <https://github.com/jbusecke>`_
+- :py:func:`~xmip.drift_removal.match_and_remove_drift` does now work with chunked (dask powered) datasets (:pull:164).By `Julius Busecke <https://github.com/jbusecke>`_
 
 Internal Changes
 ~~~~~~~~~~~~~~~~
 
-- Unit correction logic now uses pint-xarray under the hood (:pull:`160`, :issue:`31`).
+- Unit correction logic now uses pint-xarray under the hood (:pull:160, :issue:31).
 By `Tom Nicholas <https://github.com/TomNicholas>`_ and `Julius Busecke <https://github.com/jbusecke>`_
 
 
@@ -81,10 +81,10 @@ v0.5.0 (2021/7/9)
 New Features
 ~~~~~~~~~~~~
 - :py:func:`~xmip.postprocessing.interpolate_grid_labels` enables batch combination of different grid_labels
-(e.g. from native to regridded and vice versa) using xesmf (:pull:`161`). By `Julius Busecke <https://github.com/jbusecke>`_
+(e.g. from native to regridded and vice versa) using xesmf (:pull:161). By `Julius Busecke <https://github.com/jbusecke>`_
 
 - :py:func:`~xmip.drift_removal.match_and_remove_drift` enables batch detrending/drift-drift_removal
-from a dictionary of datasets (:pull:`155`). By `Julius Busecke <https://github.com/jbusecke>`_
+from a dictionary of datasets (:pull:155). By `Julius Busecke <https://github.com/jbusecke>`_
 
 .. _whats-new.0.4.0:
 
@@ -94,9 +94,9 @@ v0.4.0 (2021/6/9)
 New Features
 ~~~~~~~~~~~~
 
-- Started implementing metadata fixes in `combined_preprocessing` (:pull:`147`). By `Julius Busecke <https://github.com/jbusecke>`_
+- Started implementing metadata fixes in `combined_preprocessing` (:pull:147). By `Julius Busecke <https://github.com/jbusecke>`_
 
-- Added `drift_removal` which adds ability to align time of branched runs and remove drift from the parent (e.g. control) run (:pull:`126`, :pull:`148`). By `Julius Busecke <https://github.com/jbusecke>`_
+- Added `drift_removal` which adds ability to align time of branched runs and remove drift from the parent (e.g. control) run (:pull:126, :pull:148). By `Julius Busecke <https://github.com/jbusecke>`_
 
 .. _whats-new.0.3.0:
 
@@ -105,13 +105,13 @@ v0.3.0 (2021/6/9)
 
 New Features
 ~~~~~~~~~~~~
-- Added `postprocessing` module and added ability to parse metrics to multiple datasets in a dictionary (:pull:`110`, :pull:`117`). By `Julius Busecke <https://github.com/jbusecke>`_
+- Added `postprocessing` module and added ability to parse metrics to multiple datasets in a dictionary (:pull:110, :pull:117). By `Julius Busecke <https://github.com/jbusecke>`_
 
 
 Internal Changes
 ~~~~~~~~~~~~~~~~
 
-- Refactored CI internals, added dependabot, and some updated failcases (:pull:`121`, :pull:`128`, :pull:`129`, :pull:`133`, :pull:`134`, :pull:`135`). By `Julius Busecke <https://github.com/jbusecke>`_
+- Refactored CI internals, added dependabot, and some updated failcases (:pull:121, :pull:128, :pull:129, :pull:133, :pull:134, :pull:135). By `Julius Busecke <https://github.com/jbusecke>`_
 
 .. _whats-new.0.2.0:
 
@@ -120,32 +120,32 @@ v0.2.0 (2021/4/9)
 
 Breaking changes
 ~~~~~~~~~~~~~~~~
-- Removed `replace_x_y_nominal_lat_lon` from `combined_preprocessing` due to ongoing performance issues with dask (:issue:`75`, :issue:`85`, :issue:`94`) (:pull:`104`). By `Julius Busecke <https://github.com/jbusecke>`_
-- Further refactor of `replace_x_y_nominal_lat_lon`, which avoids missing values in the dimension coordinates (:issue:`66`) (:pull:`79`). By `Julius Busecke <https://github.com/jbusecke>`_
+- Removed `replace_x_y_nominal_lat_lon` from `combined_preprocessing` due to ongoing performance issues with dask (:issue:75, :issue:85, :issue:94) (:pull:104). By `Julius Busecke <https://github.com/jbusecke>`_
+- Further refactor of `replace_x_y_nominal_lat_lon`, which avoids missing values in the dimension coordinates (:issue:66) (:pull:79). By `Julius Busecke <https://github.com/jbusecke>`_
 
 - Consistent treatment of cf-style bounds. The combination of `parse_lon_lat_bounds`,`maybe_convert_bounds_to_vertex`, `maybe_convert_vertex_to_bounds`, and `sort_vertex_order` applied on the dataset, assures that all datasets have both conventions available and the vertex order is the same. By `Julius Busecke <https://github.com/jbusecke>`_
 
-- New implementation of `replace_x_y_nominal_lat_lon`, which avoids duplicate values in the derived dimensions (:issue:`34`) (:pull:`35`). By `Julius Busecke <https://github.com/jbusecke>`_
+- New implementation of `replace_x_y_nominal_lat_lon`, which avoids duplicate values in the derived dimensions (:issue:34) (:pull:35). By `Julius Busecke <https://github.com/jbusecke>`_
 
 New Features
 ~~~~~~~~~~~~
-- Create merged region masks with :py:func:`merged_mask` (:pull:`18`). By `Julius Busecke <https://github.com/jbusecke>`_
+- Create merged region masks with :py:func:`merged_mask` (:pull:18). By `Julius Busecke <https://github.com/jbusecke>`_
 
 
 Bug fixes
 ~~~~~~~~~
-- Updated cmip6 catalog location for the pangeo gc archive (:issue:`80`) (:pull:`81`). By `Julius Busecke <https://github.com/jbusecke>`_
+- Updated cmip6 catalog location for the pangeo gc archive (:issue:80) (:pull:81). By `Julius Busecke <https://github.com/jbusecke>`_
 
 
 Documentation
 ~~~~~~~~~~~~~
-- Sphinx/RTD documentation, including contributor guide and new logo 🤗. (:issue:`27`) (:pull:`99`).
+- Sphinx/RTD documentation, including contributor guide and new logo 🤗. (:issue:27) (:pull:99).
 
 Internal Changes
 ~~~~~~~~~~~~~~~~
-- Adds options to skip extensive cloud ci by using [skip-ci] in commit message. Adds the ability to cancel previous GHA jobs to prevent long wait times for rapid pushes. (:pull:`99`) By `Julius Busecke <https://github.com/jbusecke>`_.
+- Adds options to skip extensive cloud ci by using [skip-ci] in commit message. Adds the ability to cancel previous GHA jobs to prevent long wait times for rapid pushes. (:pull:99) By `Julius Busecke <https://github.com/jbusecke>`_.
 
--  Add `ni` and `nj` to the `rename_dict` dictionary in _preprocessing.py_ as dimensions to be corrected (:pull:`54`). By `Markus Ritschel <https://github.com/markusritschel>`_
+-  Add `ni` and `nj` to the `rename_dict` dictionary in _preprocessing.py_ as dimensions to be corrected (:pull:54). By `Markus Ritschel <https://github.com/markusritschel>`_
 
 
 .. _whats-new.0.1.2:
@@ -156,7 +156,7 @@ v0.1.2
 
 New Features
 ~~~~~~~~~~~~
-- Added more models, now supporting both ocean and atmospheric output for :py:func:`combined_preprocessing` (:pull:`14`). By `Julius Busecke <https://github.com/jbusecke>`_
+- Added more models, now supporting both ocean and atmospheric output for :py:func:`combined_preprocessing` (:pull:14). By `Julius Busecke <https://github.com/jbusecke>`_
 
 
 

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -9,15 +9,15 @@ v0.8.0 (unreleased)
 
 Internal Changes
 ~~~~~~~~~~~~~~~~
-- Add `longitude_bnds` and `latitude_bnds` to `cmip_renaming_dict` (#300). By `Joran Angevaare <https://github.com/JoranAngevaare>`
-- Updated pre-commit linting to use ruff (#359). By `Julius Busecke <https://github.com/jbusecke>`
-- Modernized packaging workflow, that runs on each PR (#361). By `Julius Busecke <https://github.com/jbusecke>`
-- Added 'nvertices' -> 'vertex' to renaming preprocessor (#357). By `Julius Busecke <https://github.com/jbusecke>`
-- Updated mamba CI + testing py311/py312 (#360, #362). By `Julius Busecke <https://github.com/jbusecke>`
+- Add `longitude_bnds` and `latitude_bnds` to `cmip_renaming_dict` (:pull:`300`). By `Joran Angevaare <https://github.com/JoranAngevaare>`
+- Updated pre-commit linting to use ruff (:pull:`359`). By `Julius Busecke <https://github.com/jbusecke>`
+- Modernized packaging workflow, that runs on each PR (:pull:`361`). By `Julius Busecke <https://github.com/jbusecke>`
+- Added 'nvertices' -> 'vertex' to renaming preprocessor (:pull:`357`). By `Julius Busecke <https://github.com/jbusecke>`
+- Updated mamba CI + testing py311/py312 (:issue:`360`, :pull:`362`). By `Julius Busecke <https://github.com/jbusecke>`
 
 Bugfixes
 ~~~~~~~~
-- Fixed cyclic interpolation in `_interp_nominal_lon` (#295, #296). By `Joran Angevaare <https://github.com/JoranAngevaare>`
+- Fixed cyclic interpolation in `_interp_nominal_lon` (:issue:`295`, :pull:`296`). By `Joran Angevaare <https://github.com/JoranAngevaare>`
 
 .. _whats-new.0.7.2:
 
@@ -26,8 +26,8 @@ v0.7.3 (unreleased)
 
 Internal Changes
 ~~~~~~~~~~~~~~~~
-- Added PR template (#304). By `Julius Busecke <https://github.com/jbusecke>`
-- Add `longitude_bnds` and `latitude_bnds` to `cmip_renaming_dict` (#300). By `Joran Angevaare <https://github.com/JoranAngevaare>`
+- Added PR template (:pull:`304`). By `Julius Busecke <https://github.com/jbusecke>`
+- Add `longitude_bnds` and `latitude_bnds` to `cmip_renaming_dict` (:pull:`300`). By `Joran Angevaare <https://github.com/JoranAngevaare>`
 
 .. _whats-new.0.7.0:
 
@@ -36,40 +36,40 @@ v0.7.0 (2023/01/03)
 
 New Features
 ~~~~~~~~~~~~
-- :py:func:`~xmip.postprocessing.match_metrics` Now allows more flexible metric matching (accepting e.g. already merged members) + better error for missing match_attrs (#275). By `Julius Busecke <https://github.com/jbusecke>`_
-- Postprocessing functions can now easily be nested on top of each other (#187). By `Julius Busecke <https://github.com/jbusecke>`_
+- :py:func:`~xmip.postprocessing.match_metrics` Now allows more flexible metric matching (accepting e.g. already merged members) + better error for missing match_attrs (:pull:`275`). By `Julius Busecke <https://github.com/jbusecke>`_
+- Postprocessing functions can now easily be nested on top of each other (:pull:`187`). By `Julius Busecke <https://github.com/jbusecke>`_
 
 
 Breaking Changes
 ~~~~~~~~~~~~~~~~
-- Requires xarray>=0.17.0 and drops support for python 3.6 (#170, #173). By `Julius Busecke <https://github.com/jbusecke>`_
-- :py:func:`~xmip.utils.cmip6_dataset_id` not includes the attribute `variable_id` (#166) By `Julius Busecke <https://github.com/jbusecke>`_
-- Dropped support for python 3.7 (#268, #267). By `Julius Busecke <https://github.com/jbusecke>`_
+- Requires xarray>=0.17.0 and drops support for python 3.6 (:pull:`170`, :pull:`173`). By `Julius Busecke <https://github.com/jbusecke>`_
+- :py:func:`~xmip.utils.cmip6_dataset_id` not includes the attribute `variable_id` (:pull:`166`) By `Julius Busecke <https://github.com/jbusecke>`_
+- Dropped support for python 3.7 (:pull:`268`, :issue:`267`). By `Julius Busecke <https://github.com/jbusecke>`_
 
 Internal Changes
 ~~~~~~~~~~~~~~~~
 
-- Unit correction logic now uses pint-xarray under the hood (#160, #31).
+- Unit correction logic now uses pint-xarray under the hood (:pull:`160`, :issue:`31`).
 By `Tom Nicholas <https://github.com/TomNicholas>`_ and `Julius Busecke <https://github.com/jbusecke>`_
 
-- License changed to Apache-2.0 (#272, #256). By `Julius Busecke <https://github.com/jbusecke>`_
+- License changed to Apache-2.0 (:pull:`272`, :issue:`256`). By `Julius Busecke <https://github.com/jbusecke>`_
 
 Bugfixes
 ~~~~~~~~
-- :py:func:`~xmip.postprocessing.concat_members` now accepts datasets which already have 'member_id' as a dimension (maintain compatibility with recent intake-esm changes) (#277). By `Julius Busecke <https://github.com/jbusecke>`_
+- :py:func:`~xmip.postprocessing.concat_members` now accepts datasets which already have 'member_id' as a dimension (maintain compatibility with recent intake-esm changes) (:pull:`277`). By `Julius Busecke <https://github.com/jbusecke>`_
 
-- :py:func:`~xmip.postprocessing.match_metrics` now accepts single variables as str input (#229, #245). By `Julius Busecke <https://github.com/jbusecke>`_
+- :py:func:`~xmip.postprocessing.match_metrics` now accepts single variables as str input (:issue:`229`, :pull:`245`). By `Julius Busecke <https://github.com/jbusecke>`_
 
-- :py:func:`~xmip.postprocessing.concat_members` now returns a dataset with labelled `member_id` dimension (#196 , #197). By `Julius Busecke <https://github.com/jbusecke>`_
+- :py:func:`~xmip.postprocessing.concat_members` now returns a dataset with labelled `member_id` dimension (:issue:`196` , :pull:`197`). By `Julius Busecke <https://github.com/jbusecke>`_
 
-- Fixes incompatibility with upstream changes in xarray>=0.19.0 (#173, #174). By `Julius Busecke <https://github.com/jbusecke>`_
+- Fixes incompatibility with upstream changes in xarray>=0.19.0 (:issue:`173`, :pull:`174`). By `Julius Busecke <https://github.com/jbusecke>`_
 
-- :py:func:`~xmip.drift_removal.match_and_remove_drift` does now work with chunked (dask powered) datasets (#164).By `Julius Busecke <https://github.com/jbusecke>`_
+- :py:func:`~xmip.drift_removal.match_and_remove_drift` does now work with chunked (dask powered) datasets (:pull:`164`).By `Julius Busecke <https://github.com/jbusecke>`_
 
 Internal Changes
 ~~~~~~~~~~~~~~~~
 
-- Unit correction logic now uses pint-xarray under the hood (#160, #31).
+- Unit correction logic now uses pint-xarray under the hood (:pull:`160`, :issue:`31`).
 By `Tom Nicholas <https://github.com/TomNicholas>`_ and `Julius Busecke <https://github.com/jbusecke>`_
 
 
@@ -81,10 +81,10 @@ v0.5.0 (2021/7/9)
 New Features
 ~~~~~~~~~~~~
 - :py:func:`~xmip.postprocessing.interpolate_grid_labels` enables batch combination of different grid_labels
-(e.g. from native to regridded and vice versa) using xesmf (#161). By `Julius Busecke <https://github.com/jbusecke>`_
+(e.g. from native to regridded and vice versa) using xesmf (:pull:`161`). By `Julius Busecke <https://github.com/jbusecke>`_
 
 - :py:func:`~xmip.drift_removal.match_and_remove_drift` enables batch detrending/drift-drift_removal
-from a dictionary of datasets (#155). By `Julius Busecke <https://github.com/jbusecke>`_
+from a dictionary of datasets (:pull:`155`). By `Julius Busecke <https://github.com/jbusecke>`_
 
 .. _whats-new.0.4.0:
 
@@ -94,9 +94,9 @@ v0.4.0 (2021/6/9)
 New Features
 ~~~~~~~~~~~~
 
-- Started implementing metadata fixes in `combined_preprocessing` (#147). By `Julius Busecke <https://github.com/jbusecke>`_
+- Started implementing metadata fixes in `combined_preprocessing` (:pull:`147`). By `Julius Busecke <https://github.com/jbusecke>`_
 
-- Added `drift_removal` which adds ability to align time of branched runs and remove drift from the parent (e.g. control) run (#126, #148). By `Julius Busecke <https://github.com/jbusecke>`_
+- Added `drift_removal` which adds ability to align time of branched runs and remove drift from the parent (e.g. control) run (:pull:`126`, :pull:`148`). By `Julius Busecke <https://github.com/jbusecke>`_
 
 .. _whats-new.0.3.0:
 
@@ -105,13 +105,13 @@ v0.3.0 (2021/6/9)
 
 New Features
 ~~~~~~~~~~~~
-- Added `postprocessing` module and added ability to parse metrics to multiple datasets in a dictionary (#110, #117). By `Julius Busecke <https://github.com/jbusecke>`_
+- Added `postprocessing` module and added ability to parse metrics to multiple datasets in a dictionary (:pull:`110`, :pull:`117`). By `Julius Busecke <https://github.com/jbusecke>`_
 
 
 Internal Changes
 ~~~~~~~~~~~~~~~~
 
-- Refactored CI internals, added dependabot, and some updated failcases (#121, #128, #129, #133, #134, #135). By `Julius Busecke <https://github.com/jbusecke>`_
+- Refactored CI internals, added dependabot, and some updated failcases (:pull:`121`, :pull:`128`, :pull:`129`, :pull:`133`, :pull:`134`, :pull:`135`). By `Julius Busecke <https://github.com/jbusecke>`_
 
 .. _whats-new.0.2.0:
 
@@ -120,32 +120,32 @@ v0.2.0 (2021/4/9)
 
 Breaking changes
 ~~~~~~~~~~~~~~~~
-- Removed `replace_x_y_nominal_lat_lon` from `combined_preprocessing` due to ongoing performance issues with dask (#75, #85, #94) (#104). By `Julius Busecke <https://github.com/jbusecke>`_
-- Further refactor of `replace_x_y_nominal_lat_lon`, which avoids missing values in the dimension coordinates (#66) (#79). By `Julius Busecke <https://github.com/jbusecke>`_
+- Removed `replace_x_y_nominal_lat_lon` from `combined_preprocessing` due to ongoing performance issues with dask (:issue:`75`, :issue:`85`, :issue:`94`) (:pull:`104`). By `Julius Busecke <https://github.com/jbusecke>`_
+- Further refactor of `replace_x_y_nominal_lat_lon`, which avoids missing values in the dimension coordinates (:issue:`66`) (:pull:`79`). By `Julius Busecke <https://github.com/jbusecke>`_
 
 - Consistent treatment of cf-style bounds. The combination of `parse_lon_lat_bounds`,`maybe_convert_bounds_to_vertex`, `maybe_convert_vertex_to_bounds`, and `sort_vertex_order` applied on the dataset, assures that all datasets have both conventions available and the vertex order is the same. By `Julius Busecke <https://github.com/jbusecke>`_
 
-- New implementation of `replace_x_y_nominal_lat_lon`, which avoids duplicate values in the derived dimensions (#34) (#35). By `Julius Busecke <https://github.com/jbusecke>`_
+- New implementation of `replace_x_y_nominal_lat_lon`, which avoids duplicate values in the derived dimensions (:issue:`34`) (:pull:`35`). By `Julius Busecke <https://github.com/jbusecke>`_
 
 New Features
 ~~~~~~~~~~~~
-- Create merged region masks with :py:func:`merged_mask` (#18). By `Julius Busecke <https://github.com/jbusecke>`_
+- Create merged region masks with :py:func:`merged_mask` (:pull:`18`). By `Julius Busecke <https://github.com/jbusecke>`_
 
 
 Bug fixes
 ~~~~~~~~~
-- Updated cmip6 catalog location for the pangeo gc archive (#80) (#81). By `Julius Busecke <https://github.com/jbusecke>`_
+- Updated cmip6 catalog location for the pangeo gc archive (:issue:`80`) (:pull:`81`). By `Julius Busecke <https://github.com/jbusecke>`_
 
 
 Documentation
 ~~~~~~~~~~~~~
-- Sphinx/RTD documentation, including contributor guide and new logo 🤗. (#27) (#99).
+- Sphinx/RTD documentation, including contributor guide and new logo 🤗. (:issue:`27`) (:pull:`99`).
 
 Internal Changes
 ~~~~~~~~~~~~~~~~
-- Adds options to skip extensive cloud ci by using [skip-ci] in commit message. Adds the ability to cancel previous GHA jobs to prevent long wait times for rapid pushes. (#99) By `Julius Busecke <https://github.com/jbusecke>`_.
+- Adds options to skip extensive cloud ci by using [skip-ci] in commit message. Adds the ability to cancel previous GHA jobs to prevent long wait times for rapid pushes. (:pull:`99`) By `Julius Busecke <https://github.com/jbusecke>`_.
 
--  Add `ni` and `nj` to the `rename_dict` dictionary in _preprocessing.py_ as dimensions to be corrected (#54). By `Markus Ritschel <https://github.com/markusritschel>`_
+-  Add `ni` and `nj` to the `rename_dict` dictionary in _preprocessing.py_ as dimensions to be corrected (:pull:`54`). By `Markus Ritschel <https://github.com/markusritschel>`_
 
 
 .. _whats-new.0.1.2:
@@ -156,7 +156,7 @@ v0.1.2
 
 New Features
 ~~~~~~~~~~~~
-- Added more models, now supporting both ocean and atmospheric output for :py:func:`combined_preprocessing` (#14). By `Julius Busecke <https://github.com/jbusecke>`_
+- Added more models, now supporting both ocean and atmospheric output for :py:func:`combined_preprocessing` (:pull:`14`). By `Julius Busecke <https://github.com/jbusecke>`_
 
 
 

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -9,15 +9,15 @@ v0.8.0 (unreleased)
 
 Internal Changes
 ~~~~~~~~~~~~~~~~
-- Add `longitude_bnds` and `latitude_bnds` to `cmip_renaming_dict` (:pull:`300`). By `Joran Angevaare <https://github.com/JoranAngevaare>`
-- Updated pre-commit linting to use ruff (:pull:`359`). By `Julius Busecke <https://github.com/jbusecke>`
-- Modernized packaging workflow, that runs on each PR (:pull:`361`). By `Julius Busecke <https://github.com/jbusecke>`
-- Added 'nvertices' -> 'vertex' to renaming preprocessor (:pull:`357`). By `Julius Busecke <https://github.com/jbusecke>`
-- Updated mamba CI + testing py311/py312 (:issue:`360`, :pull:`362`). By `Julius Busecke <https://github.com/jbusecke>`
+- Add `longitude_bnds` and `latitude_bnds` to `cmip_renaming_dict` (:pull:`300`). By `Joran Angevaare <https://github.com/JoranAngevaare>`_
+- Updated pre-commit linting to use ruff (:pull:`359`). By `Julius Busecke <https://github.com/jbusecke>`_
+- Modernized packaging workflow, that runs on each PR (:pull:`361`). By `Julius Busecke <https://github.com/jbusecke>`_
+- Added 'nvertices' -> 'vertex' to renaming preprocessor (:pull:`357`). By `Julius Busecke <https://github.com/jbusecke>`_
+- Updated mamba CI + testing py311/py312 (:issue:`360`, :pull:`362`). By `Julius Busecke <https://github.com/jbusecke>`_
 
 Bugfixes
 ~~~~~~~~
-- Fixed cyclic interpolation in `_interp_nominal_lon` (:issue:`295`, :pull:`296`). By `Joran Angevaare <https://github.com/JoranAngevaare>`
+- Fixed cyclic interpolation in `_interp_nominal_lon` (:issue:`295`, :pull:`296`). By `Joran Angevaare <https://github.com/JoranAngevaare>`_
 
 .. _whats-new.0.7.2:
 
@@ -26,8 +26,8 @@ v0.7.3 (unreleased)
 
 Internal Changes
 ~~~~~~~~~~~~~~~~
-- Added PR template (:pull:`304`). By `Julius Busecke <https://github.com/jbusecke>`
-- Add `longitude_bnds` and `latitude_bnds` to `cmip_renaming_dict` (:pull:`300`). By `Joran Angevaare <https://github.com/JoranAngevaare>`
+- Added PR template (:pull:`304`). By `Julius Busecke <https://github.com/jbusecke>`_
+- Add `longitude_bnds` and `latitude_bnds` to `cmip_renaming_dict` (:pull:`300`). By `Joran Angevaare <https://github.com/JoranAngevaare>`_
 
 .. _whats-new.0.7.0:
 

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -9,15 +9,15 @@ v0.8.0 (unreleased)
 
 Internal Changes
 ~~~~~~~~~~~~~~~~
-- Add `longitude_bnds` and `latitude_bnds` to `cmip_renaming_dict` (:pull:300). By `Joran Angevaare <https://github.com/JoranAngevaare>`
-- Updated pre-commit linting to use ruff (:pull:359). By `Julius Busecke <https://github.com/jbusecke>`
-- Modernized packaging workflow, that runs on each PR (:pull:361). By `Julius Busecke <https://github.com/jbusecke>`
-- Added 'nvertices' -> 'vertex' to renaming preprocessor (:pull:357). By `Julius Busecke <https://github.com/jbusecke>`
-- Updated mamba CI + testing py311/py312 (:issue:360, :pull:362). By `Julius Busecke <https://github.com/jbusecke>`
+- Add `longitude_bnds` and `latitude_bnds` to `cmip_renaming_dict` (#300). By `Joran Angevaare <https://github.com/JoranAngevaare>`
+- Updated pre-commit linting to use ruff (#359). By `Julius Busecke <https://github.com/jbusecke>`
+- Modernized packaging workflow, that runs on each PR (#361). By `Julius Busecke <https://github.com/jbusecke>`
+- Added 'nvertices' -> 'vertex' to renaming preprocessor (#357). By `Julius Busecke <https://github.com/jbusecke>`
+- Updated mamba CI + testing py311/py312 (#360, #362). By `Julius Busecke <https://github.com/jbusecke>`
 
 Bugfixes
 ~~~~~~~~
-- Fixed cyclic interpolation in `_interp_nominal_lon` (:issue:295, :pull:296). By `Joran Angevaare <https://github.com/JoranAngevaare>`
+- Fixed cyclic interpolation in `_interp_nominal_lon` (#295, #296). By `Joran Angevaare <https://github.com/JoranAngevaare>`
 
 .. _whats-new.0.7.2:
 
@@ -26,8 +26,8 @@ v0.7.3 (unreleased)
 
 Internal Changes
 ~~~~~~~~~~~~~~~~
-- Added PR template (:pull:304). By `Julius Busecke <https://github.com/jbusecke>`
-- Add `longitude_bnds` and `latitude_bnds` to `cmip_renaming_dict` (:pull:300). By `Joran Angevaare <https://github.com/JoranAngevaare>`
+- Added PR template (#304). By `Julius Busecke <https://github.com/jbusecke>`
+- Add `longitude_bnds` and `latitude_bnds` to `cmip_renaming_dict` (#300). By `Joran Angevaare <https://github.com/JoranAngevaare>`
 
 .. _whats-new.0.7.0:
 
@@ -36,40 +36,40 @@ v0.7.0 (2023/01/03)
 
 New Features
 ~~~~~~~~~~~~
-- :py:func:`~xmip.postprocessing.match_metrics` Now allows more flexible metric matching (accepting e.g. already merged members) + better error for missing match_attrs (:pull:275). By `Julius Busecke <https://github.com/jbusecke>`_
-- Postprocessing functions can now easily be nested on top of each other (:pull:187). By `Julius Busecke <https://github.com/jbusecke>`_
+- :py:func:`~xmip.postprocessing.match_metrics` Now allows more flexible metric matching (accepting e.g. already merged members) + better error for missing match_attrs (#275). By `Julius Busecke <https://github.com/jbusecke>`_
+- Postprocessing functions can now easily be nested on top of each other (#187). By `Julius Busecke <https://github.com/jbusecke>`_
 
 
 Breaking Changes
 ~~~~~~~~~~~~~~~~
-- Requires xarray>=0.17.0 and drops support for python 3.6 (:pull:170, :pull:173). By `Julius Busecke <https://github.com/jbusecke>`_
-- :py:func:`~xmip.utils.cmip6_dataset_id` not includes the attribute `variable_id` (:pull:166) By `Julius Busecke <https://github.com/jbusecke>`_
-- Dropped support for python 3.7 (:pull:268, :issue:267). By `Julius Busecke <https://github.com/jbusecke>`_
+- Requires xarray>=0.17.0 and drops support for python 3.6 (#170, #173). By `Julius Busecke <https://github.com/jbusecke>`_
+- :py:func:`~xmip.utils.cmip6_dataset_id` not includes the attribute `variable_id` (#166) By `Julius Busecke <https://github.com/jbusecke>`_
+- Dropped support for python 3.7 (#268, #267). By `Julius Busecke <https://github.com/jbusecke>`_
 
 Internal Changes
 ~~~~~~~~~~~~~~~~
 
-- Unit correction logic now uses pint-xarray under the hood (:pull:160, :issue:31).
+- Unit correction logic now uses pint-xarray under the hood (#160, #31).
 By `Tom Nicholas <https://github.com/TomNicholas>`_ and `Julius Busecke <https://github.com/jbusecke>`_
 
-- License changed to Apache-2.0 (:pull:272, :issue:256). By `Julius Busecke <https://github.com/jbusecke>`_
+- License changed to Apache-2.0 (#272, #256). By `Julius Busecke <https://github.com/jbusecke>`_
 
 Bugfixes
 ~~~~~~~~
-- :py:func:`~xmip.postprocessing.concat_members` now accepts datasets which already have 'member_id' as a dimension (maintain compatibility with recent intake-esm changes) (:pull:277). By `Julius Busecke <https://github.com/jbusecke>`_
+- :py:func:`~xmip.postprocessing.concat_members` now accepts datasets which already have 'member_id' as a dimension (maintain compatibility with recent intake-esm changes) (#277). By `Julius Busecke <https://github.com/jbusecke>`_
 
-- :py:func:`~xmip.postprocessing.match_metrics` now accepts single variables as str input (:issue:229, :pull:245). By `Julius Busecke <https://github.com/jbusecke>`_
+- :py:func:`~xmip.postprocessing.match_metrics` now accepts single variables as str input (#229, #245). By `Julius Busecke <https://github.com/jbusecke>`_
 
-- :py:func:`~xmip.postprocessing.concat_members` now returns a dataset with labelled `member_id` dimension (:issue:196 , :pull:197). By `Julius Busecke <https://github.com/jbusecke>`_
+- :py:func:`~xmip.postprocessing.concat_members` now returns a dataset with labelled `member_id` dimension (#196 , #197). By `Julius Busecke <https://github.com/jbusecke>`_
 
-- Fixes incompatibility with upstream changes in xarray>=0.19.0 (:issue:173, :pull:174). By `Julius Busecke <https://github.com/jbusecke>`_
+- Fixes incompatibility with upstream changes in xarray>=0.19.0 (#173, #174). By `Julius Busecke <https://github.com/jbusecke>`_
 
-- :py:func:`~xmip.drift_removal.match_and_remove_drift` does now work with chunked (dask powered) datasets (:pull:164).By `Julius Busecke <https://github.com/jbusecke>`_
+- :py:func:`~xmip.drift_removal.match_and_remove_drift` does now work with chunked (dask powered) datasets (#164).By `Julius Busecke <https://github.com/jbusecke>`_
 
 Internal Changes
 ~~~~~~~~~~~~~~~~
 
-- Unit correction logic now uses pint-xarray under the hood (:pull:160, :issue:31).
+- Unit correction logic now uses pint-xarray under the hood (#160, #31).
 By `Tom Nicholas <https://github.com/TomNicholas>`_ and `Julius Busecke <https://github.com/jbusecke>`_
 
 
@@ -81,10 +81,10 @@ v0.5.0 (2021/7/9)
 New Features
 ~~~~~~~~~~~~
 - :py:func:`~xmip.postprocessing.interpolate_grid_labels` enables batch combination of different grid_labels
-(e.g. from native to regridded and vice versa) using xesmf (:pull:161). By `Julius Busecke <https://github.com/jbusecke>`_
+(e.g. from native to regridded and vice versa) using xesmf (#161). By `Julius Busecke <https://github.com/jbusecke>`_
 
 - :py:func:`~xmip.drift_removal.match_and_remove_drift` enables batch detrending/drift-drift_removal
-from a dictionary of datasets (:pull:155). By `Julius Busecke <https://github.com/jbusecke>`_
+from a dictionary of datasets (#155). By `Julius Busecke <https://github.com/jbusecke>`_
 
 .. _whats-new.0.4.0:
 
@@ -94,9 +94,9 @@ v0.4.0 (2021/6/9)
 New Features
 ~~~~~~~~~~~~
 
-- Started implementing metadata fixes in `combined_preprocessing` (:pull:147). By `Julius Busecke <https://github.com/jbusecke>`_
+- Started implementing metadata fixes in `combined_preprocessing` (#147). By `Julius Busecke <https://github.com/jbusecke>`_
 
-- Added `drift_removal` which adds ability to align time of branched runs and remove drift from the parent (e.g. control) run (:pull:126, :pull:148). By `Julius Busecke <https://github.com/jbusecke>`_
+- Added `drift_removal` which adds ability to align time of branched runs and remove drift from the parent (e.g. control) run (#126, #148). By `Julius Busecke <https://github.com/jbusecke>`_
 
 .. _whats-new.0.3.0:
 
@@ -105,13 +105,13 @@ v0.3.0 (2021/6/9)
 
 New Features
 ~~~~~~~~~~~~
-- Added `postprocessing` module and added ability to parse metrics to multiple datasets in a dictionary (:pull:110, :pull:117). By `Julius Busecke <https://github.com/jbusecke>`_
+- Added `postprocessing` module and added ability to parse metrics to multiple datasets in a dictionary (#110, #117). By `Julius Busecke <https://github.com/jbusecke>`_
 
 
 Internal Changes
 ~~~~~~~~~~~~~~~~
 
-- Refactored CI internals, added dependabot, and some updated failcases (:pull:121, :pull:128, :pull:129, :pull:133, :pull:134, :pull:135). By `Julius Busecke <https://github.com/jbusecke>`_
+- Refactored CI internals, added dependabot, and some updated failcases (#121, #128, #129, #133, #134, #135). By `Julius Busecke <https://github.com/jbusecke>`_
 
 .. _whats-new.0.2.0:
 
@@ -120,32 +120,32 @@ v0.2.0 (2021/4/9)
 
 Breaking changes
 ~~~~~~~~~~~~~~~~
-- Removed `replace_x_y_nominal_lat_lon` from `combined_preprocessing` due to ongoing performance issues with dask (:issue:75, :issue:85, :issue:94) (:pull:104). By `Julius Busecke <https://github.com/jbusecke>`_
-- Further refactor of `replace_x_y_nominal_lat_lon`, which avoids missing values in the dimension coordinates (:issue:66) (:pull:79). By `Julius Busecke <https://github.com/jbusecke>`_
+- Removed `replace_x_y_nominal_lat_lon` from `combined_preprocessing` due to ongoing performance issues with dask (#75, #85, #94) (#104). By `Julius Busecke <https://github.com/jbusecke>`_
+- Further refactor of `replace_x_y_nominal_lat_lon`, which avoids missing values in the dimension coordinates (#66) (#79). By `Julius Busecke <https://github.com/jbusecke>`_
 
 - Consistent treatment of cf-style bounds. The combination of `parse_lon_lat_bounds`,`maybe_convert_bounds_to_vertex`, `maybe_convert_vertex_to_bounds`, and `sort_vertex_order` applied on the dataset, assures that all datasets have both conventions available and the vertex order is the same. By `Julius Busecke <https://github.com/jbusecke>`_
 
-- New implementation of `replace_x_y_nominal_lat_lon`, which avoids duplicate values in the derived dimensions (:issue:34) (:pull:35). By `Julius Busecke <https://github.com/jbusecke>`_
+- New implementation of `replace_x_y_nominal_lat_lon`, which avoids duplicate values in the derived dimensions (#34) (#35). By `Julius Busecke <https://github.com/jbusecke>`_
 
 New Features
 ~~~~~~~~~~~~
-- Create merged region masks with :py:func:`merged_mask` (:pull:18). By `Julius Busecke <https://github.com/jbusecke>`_
+- Create merged region masks with :py:func:`merged_mask` (#18). By `Julius Busecke <https://github.com/jbusecke>`_
 
 
 Bug fixes
 ~~~~~~~~~
-- Updated cmip6 catalog location for the pangeo gc archive (:issue:80) (:pull:81). By `Julius Busecke <https://github.com/jbusecke>`_
+- Updated cmip6 catalog location for the pangeo gc archive (#80) (#81). By `Julius Busecke <https://github.com/jbusecke>`_
 
 
 Documentation
 ~~~~~~~~~~~~~
-- Sphinx/RTD documentation, including contributor guide and new logo 🤗. (:issue:27) (:pull:99).
+- Sphinx/RTD documentation, including contributor guide and new logo 🤗. (#27) (#99).
 
 Internal Changes
 ~~~~~~~~~~~~~~~~
-- Adds options to skip extensive cloud ci by using [skip-ci] in commit message. Adds the ability to cancel previous GHA jobs to prevent long wait times for rapid pushes. (:pull:99) By `Julius Busecke <https://github.com/jbusecke>`_.
+- Adds options to skip extensive cloud ci by using [skip-ci] in commit message. Adds the ability to cancel previous GHA jobs to prevent long wait times for rapid pushes. (#99) By `Julius Busecke <https://github.com/jbusecke>`_.
 
--  Add `ni` and `nj` to the `rename_dict` dictionary in _preprocessing.py_ as dimensions to be corrected (:pull:54). By `Markus Ritschel <https://github.com/markusritschel>`_
+-  Add `ni` and `nj` to the `rename_dict` dictionary in _preprocessing.py_ as dimensions to be corrected (#54). By `Markus Ritschel <https://github.com/markusritschel>`_
 
 
 .. _whats-new.0.1.2:
@@ -156,7 +156,7 @@ v0.1.2
 
 New Features
 ~~~~~~~~~~~~
-- Added more models, now supporting both ocean and atmospheric output for :py:func:`combined_preprocessing` (:pull:14). By `Julius Busecke <https://github.com/jbusecke>`_
+- Added more models, now supporting both ocean and atmospheric output for :py:func:`combined_preprocessing` (#14). By `Julius Busecke <https://github.com/jbusecke>`_
 
 
 

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -18,6 +18,7 @@ Internal Changes
 Bugfixes
 ~~~~~~~~
 - Fixed cyclic interpolation in `_interp_nominal_lon` (:issue:`295`, :pull:`296`). By `Joran Angevaare <https://github.com/JoranAngevaare>`_
+- Fix formatting `whatsnew.rst` for doc-building (:pull:`366`). By `Joran Angevaare <https://github.com/JoranAngevaare>`_
 
 .. _whats-new.0.7.2:
 


### PR DESCRIPTION
## Fix documentation building
This is probably more related to one sub-packages of sphinx that is actually causing the issue, but I think this should do the trick to get the documentation building back up.

New page is on:
https://cmip6-preprocessing--366.org.readthedocs.build/en/366/whats-new.html

1. First try ([6474e49](https://github.com/jbusecke/xMIP/pull/366/commits/6474e490b4d39f012609a055edfcda84afd350de)) did look to kind of bad looking information:
![image](https://github.com/jbusecke/xMIP/assets/22295914/79ad405f-964f-4ea1-8533-60eecf0657b7)

2. Second try ([de712ae](https://github.com/jbusecke/xMIP/pull/366/commits/de712aecf65746c54ccf2f26089f9d89fba901a9)) also yielded something horrible
![image](https://github.com/jbusecke/xMIP/assets/22295914/84248c26-8549-49a3-8686-adbcc1e48ec2)

3. The third try ([fdbe8c3](https://github.com/jbusecke/xMIP/pull/366/commits/fdbe8c3fac6d2b5c12629983c78c825ab5d52a69)) actually fixes the issue
![image](https://github.com/jbusecke/xMIP/assets/22295914/952f9461-4f2d-4ed8-a037-a0fa3e906cb9)

4. The fourth commit fixes the strange rst syntax which no one remembers [ef138c9](https://github.com/jbusecke/xMIP/pull/366/commits/ef138c99a6e0338085608136d07325d971b90377). Now the hyperlinks to the authors work.
![image](https://github.com/jbusecke/xMIP/assets/22295914/2cdc59ce-4752-430b-97ca-42982887839d)

5. Commit nr. 5/6 adds this PR to the `whats-new.rst`