### PR TITLE
Add 'bound' to the bounds dimension labels

### DIFF
--- a/xmip/preprocessing.py
+++ b/xmip/preprocessing.py
@@ -27,7 +27,7 @@ def cmip6_renaming_dict():
         "x": ["i", "ni", "xh", "nlon"],
         "y": ["j", "nj", "yh", "nlat"],
         "lev": ["deptht", "olevel", "zlev", "olev", "depth"],
-        "bnds": ["bnds", "axis_nbounds", "d2"],
+        "bnds": ["bnds", "axis_nbounds", "d2", "bound"],
         "vertex": ["vertex", "nvertex", "vertices", "nvertices"],
         # coordinate labels
         "lon": ["longitude", "nav_lon"],


### PR DESCRIPTION
Some models (e.g. E3SM-1-0) use "bound" as a dimension name. This pull request is for adding this option in dim labels in `cmip6_renaming_dict` function.

